### PR TITLE
typing hints

### DIFF
--- a/motion/client.py
+++ b/motion/client.py
@@ -166,7 +166,7 @@ class ClientConnection:
         *,
         relation: str,
         identifier: str,
-        key_values: dict[str, typing.Any],
+        key_values: typing.Dict[str, typing.Any],
     ) -> typing.Any:
         # Convert enums to their values
 

--- a/motion/cursor.py
+++ b/motion/cursor.py
@@ -23,18 +23,18 @@ class Cursor:
         self,
         *,
         name: str,
-        relations: dict[str, pa.Table],
+        relations: typing.Dict[str, pa.Table],
         log_table: pa.Table,
-        table_columns: dict[str, list[str]],
-        triggers: dict[str, list[TriggerFn]],
+        table_columns: typing.Dict[str, list[str]],
+        triggers: typing.Dict[str, list[TriggerFn]],
         write_lock: threading.Lock,
         session_id: str,
         wait_for_results: bool = False,
-        triggers_to_run_on_duplicate: dict[TriggerFn, TriggerElement] = {},
+        triggers_to_run_on_duplicate: typing.Dict[TriggerFn, TriggerElement] = {},
         spawned_by: TriggerElement = None,  # type: ignore
     ):
         self.name = name
-        self.relations: dict[str, pa.Table] = relations
+        self.relations: typing.Dict[str, pa.Table] = relations
         self.log_table = log_table
         self.table_columns = table_columns
         self.triggers = triggers
@@ -101,7 +101,7 @@ class Cursor:
         self,
         *,
         relation: str,
-        key_values: dict[str, typing.Any],
+        key_values: typing.Dict[str, typing.Any],
         identifier: str = "",
     ) -> str:
         """Set multiple values for a key in a relation.
@@ -176,7 +176,7 @@ class Cursor:
                 self.relations[relation] = final_table
 
         # Get all triggers to run
-        triggers_to_run: dict[TriggerFn, TriggerElement] = {}
+        triggers_to_run: typing.Dict[TriggerFn, TriggerElement] = {}
         for key, value in key_values.items():
             if f"{relation}.{key}" not in self.triggers:
                 continue
@@ -245,7 +245,7 @@ class Cursor:
         *,
         trigger: TriggerFn,
         triggered_by: TriggerElement,
-        triggers_to_run_on_duplicate: dict[TriggerFn, TriggerElement] = {},
+        triggers_to_run_on_duplicate: typing.Dict[TriggerFn, TriggerElement] = {},
     ) -> None:
         """Execute a trigger.
 
@@ -265,7 +265,7 @@ class Cursor:
         self,
         trigger: TriggerFn,
         triggered_by: TriggerElement,
-        triggers_to_run_on_duplicate: dict[TriggerFn, TriggerElement] = {},
+        triggers_to_run_on_duplicate: typing.Dict[TriggerFn, TriggerElement] = {},
     ) -> None:
         """Execute a trigger.
 

--- a/motion/store.py
+++ b/motion/store.py
@@ -49,11 +49,11 @@ class Store:
             self.addLogTable_pa()
 
         # Set up triggers
-        self.triggers: dict[str, list[TriggerFn]] = {}
-        self.cron_triggers: dict[str, list[TriggerFn]] = {}
-        self.cron_threads: dict[str, CronThread] = {}
-        self.trigger_names: dict[str, list[str]] = {}
-        self.trigger_fns: dict[str, Trigger] = {}
+        self.triggers: typing.Dict[str, list[TriggerFn]] = {}
+        self.cron_triggers: typing.Dict[str, list[TriggerFn]] = {}
+        self.cron_threads: typing.Dict[str, CronThread] = {}
+        self.trigger_names: typing.Dict[str, list[str]] = {}
+        self.trigger_fns: typing.Dict[str, Trigger] = {}
 
     def __del__(self) -> None:
         self.stop(wait=False)
@@ -218,7 +218,7 @@ class Store:
         self,
         name: str,
         trigger: typing.Type[Trigger],
-        params: dict[str, typing.Any] = {},
+        params: typing.Dict[str, typing.Any] = {},
     ) -> None:
         """Adds a trigger to the store.
 
@@ -327,7 +327,7 @@ class Store:
         names_and_fns = self.triggers.get(f"{relation}.{key}", [])
         return [t[0] for t in names_and_fns]
 
-    def getTriggersForAllKeys(self) -> dict[str, list[str]]:
+    def getTriggersForAllKeys(self) -> typing.Dict[str, list[str]]:
         """Get the list of triggers for all keys.
 
         Returns:


### PR DESCRIPTION
Change typing hints to typing.Dict[] instead of dict[] to work with python 3.8