### PR TITLE
Fixes bugs in `get` and `mget`

### DIFF
--- a/motion/api/api.py
+++ b/motion/api/api.py
@@ -62,7 +62,7 @@ def create_fastapi_app(store: Store, testing: bool = False) -> FastAPI:
 
         # Check if the result is a pandas df
         if isinstance(res, dict):
-            res = pd.DataFrame(res, index=[0])
+            res = pd.DataFrame([res])
 
         elif not isinstance(res, pd.DataFrame):
             res = pd.DataFrame(res)
@@ -77,7 +77,7 @@ def create_fastapi_app(store: Store, testing: bool = False) -> FastAPI:
         )
         # Check if the result is a pandas df
         if isinstance(res, dict):
-            res = pd.DataFrame(res, index=[0])
+            res = pd.DataFrame([res])
 
         elif not isinstance(res, pd.DataFrame):
             res = pd.DataFrame(res)

--- a/motion/client.py
+++ b/motion/client.py
@@ -177,6 +177,12 @@ class ClientConnection:
         Returns:
             pd.DataFrame: The values for the key.
         """
+        if not isinstance(identifiers, list):
+            try:
+                identifiers = list(identifiers)
+            except Exception:
+                raise TypeError("identifiers must be a list or iterable")
+
         args = {
             "relation": relation,
             "identifiers": identifiers,

--- a/motion/client.py
+++ b/motion/client.py
@@ -216,7 +216,7 @@ class ClientConnection:
         if identifier is None:
             identifier = ""
 
-        df = pd.DataFrame(key_values, index=[0])
+        df = pd.DataFrame([key_values])
         memory_buffer = io.BytesIO()
         df.to_parquet(memory_buffer, engine="pyarrow", index=False)
         memory_buffer.seek(0)

--- a/motion/cursor.py
+++ b/motion/cursor.py
@@ -155,7 +155,7 @@ class Cursor:
                     }
                 )
                 new_row_dict.update(key_values)
-                new_row_df = pd.DataFrame(new_row_dict, index=[0])
+                new_row_df = pd.DataFrame([new_row_dict])
                 new_row = pa.Table.from_pandas(new_row_df, schema=table.schema)
 
                 # Check schemas match

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -124,6 +124,55 @@ def test_python_get(test_client):
     assert not results
 
 
+@pytest.fixture
+def test_client_with_list_key(double_age_trigger):
+    class Test(motion.Schema):
+        name: str
+        age: int
+        doubled_age: int
+        likes: list[str]
+
+    config = {
+        "application": {
+            "name": "testlistkey",
+            "author": "shreyashankar",
+            "version": "0.1",
+        },
+        "relations": [Test],
+        "triggers": [double_age_trigger],
+    }
+
+    connection = motion.test(config, session_id="TESTING")
+    yield connection
+
+    # Close connection
+    connection.close(wait=False)
+
+
+def test_python_get_with_list_key(test_client_with_list_key):
+    # Create store and client
+    connection = test_client_with_list_key
+
+    # Set some data
+    student_id = connection.set(
+        relation="Test",
+        identifier="",  # Let the client generate an identifier
+        key_values={
+            "name": "Mary",
+            "age": random.randint(10, 30),
+            "likes": ["cats", "dogs"],
+        },
+    )
+
+    # Specify all keywords
+    results = connection.get(
+        identifier=student_id, relation="Test", keys=["*"]
+    )
+
+    assert results["likes"][0] == "cats"
+    assert results["likes"][1] == "dogs"
+
+
 def test_python_mget(test_client):
     connection = test_client
 

--- a/tests/test_python_api.py
+++ b/tests/test_python_api.py
@@ -6,6 +6,7 @@ Tests the following api functions:
 
 """
 import motion
+import numpy as np
 import os
 import pytest
 import random
@@ -238,6 +239,15 @@ def test_python_mget(test_client):
         include_derived=False,
     )
     assert len(results) == 1
+
+    # Test passing in numpy array of IDs
+    results = connection.mget(
+        identifiers=np.array([student_id, student_id_2]),
+        relation="Test",
+        keys=["*"],
+        as_df=True,
+        include_derived=True,
+    )
 
 
 def test_python_sql(test_client):


### PR DESCRIPTION
## Description

Fixes 2 bugs:

1. `mget` can now accept any iterable of identifiers. Previously it would error out for np arrays, for instance.
2. `get` for a list key would error. Now it works as intended.

## Related Issues

Closes #106 

## Checklist

Please make sure that you have completed the following items before submitting this pull request:

- [ ] Code is up-to-date with the main branch
- [ ] Code has been tested locally and all tests pass
- [ ] Code changes have been documented (if necessary)
- [ ] Code changes adhere to the project's coding standards
- [ ] Any necessary new dependencies have been added to the project's `pyproject.toml` file

