### PR TITLE
Allow read state to run anytime

### DIFF
--- a/motion/execute.py
+++ b/motion/execute.py
@@ -17,8 +17,10 @@ class Executor:
     ):
         self._instance_name = instance_name
         self._cleanup = cleanup
-        self._first_run = True  # Use this to determine whether to run setUp
         self._init_state_func = init_state_func
+
+        # Set up state
+        self.setUp()
 
         # Set up routes
         self._infer_routes: Dict[str, Route] = infer_routes
@@ -135,13 +137,6 @@ class Executor:
         key, value = next(iter(kwargs.items()))
         route_hit = False
         infer_result = None
-
-        if self._first_run:
-            # Set up state
-            logger.info(f"Setting up {self._instance_name} state for the first run...")
-            self.setUp()
-            logger.info(f"Finished setting up {self._instance_name} state.")
-            self._first_run = False
 
         # Run the infer route
         if key in self._infer_routes.keys():

--- a/motion/instance.py
+++ b/motion/instance.py
@@ -100,7 +100,6 @@ class ComponentInstance:
 
     def read_state(self, key: str) -> Any:
         """Gets the current value for the key in the component's state.
-        Can only be called if the component has been run at least once.
 
         Usage:
         ```python
@@ -115,7 +114,7 @@ class ComponentInstance:
         # Define infer and fit operations
 
         c_instance = C()
-        c_instance.read_state("value") # This will raise an error
+        c_instance.read_state("value") # Returns 0
         c_instance.run(...)
         c_instance.read_state("value") # This will return the current value of
         # "value" in the state
@@ -127,9 +126,6 @@ class ComponentInstance:
         Returns:
             Any: Current value for the key.
         """
-        if self._executor._first_run:
-            raise ValueError("Cannot read state when component has not been run yet.")
-
         return self._executor.state[key]
 
     def run(self, **kwargs: Any) -> Union[Any, Tuple[Any, FitEventGroup]]:

--- a/tests/component/test_counter.py
+++ b/tests/component/test_counter.py
@@ -19,9 +19,7 @@ def test_create():
 
     c = Counter()
 
-    with pytest.raises(ValueError):
-        # Read state before run
-        c.read_state("value")
+    assert c.read_state("value") == 0
 
     assert c.run(number=1)[1] == 1
     _, fit_event = c.run(number=2, return_fit_event=True)


### PR DESCRIPTION
## Description

Moves `setUp` to the constructor of the executor, so `read_state` can run anytime