### PR TITLE
Add update state method for component instance

### DIFF
--- a/docs/api/component-instance.md
+++ b/docs/api/component-instance.md
@@ -4,6 +4,7 @@
         members: 
             - run
             - read_state
+            - update_state
             - flush_fit
             - version
             - shutdown

--- a/motion/instance.py
+++ b/motion/instance.py
@@ -129,8 +129,11 @@ class ComponentInstance:
         """
         return self._executor.version  # type: ignore
 
-    def read_state(self, key: str) -> Any:
-        """Gets the current value for the key in the component's state.
+    def update_state(self, state_update: Dict[str, Any]) -> None:
+        """Writes the state update to the component instance's state.
+        If a fit op is currently running, the state update will be
+        applied after the fit op is finished. Warning: this could
+        take a while if your fit op takes a long time!
 
         Usage:
         ```python
@@ -143,12 +146,44 @@ class ComponentInstance:
             return {"value": 0}
 
         # Define infer and fit operations
+        ...
 
-        c_instance = C()
-        c_instance.read_state("value") # Returns 0
-        c_instance.run(...)
-        c_instance.read_state("value") # This will return the current value of
-        # "value" in the state
+        if __name__ == "__main__":
+            c_instance = C()
+            c_instance.read_state("value") # Returns 0
+            c_instance.update_state({"value": 1, "value2": 2})
+            c_instance.read_state("value") # Returns 1
+            c_instance.read_state("value2") # Returns 2
+        ```
+
+        Args:
+            state_update (Dict[str, Any]): Dictionary of key-value pairs
+                to update the state with.
+        """
+        self._executor._updateState(state_update)
+
+    def read_state(self, key: str) -> Any:
+        """Gets the current value for the key in the component instance's state.
+
+        Usage:
+        ```python
+        from motion import Component
+
+        C = Component("MyComponent")
+
+        @C.init_state
+        def setUp():
+            return {"value": 0}
+
+        # Define infer and fit operations
+        ...
+
+        if __name__ == "__main__":
+            c_instance = C()
+            c_instance.read_state("value") # Returns 0
+            c_instance.run(...)
+            c_instance.read_state("value") # This will return the current value
+            # of "value" in the state
         ```
 
         Args:

--- a/tests/state/test_write.py
+++ b/tests/state/test_write.py
@@ -1,0 +1,28 @@
+from motion import Component
+
+import pytest
+
+C = Component("MyComponent")
+
+
+@C.init_state
+def setUp():
+    return {"value": 0}
+
+
+def test_update_state():
+    c_instance = C()
+    assert c_instance.read_state("value") == 0
+    c_instance.update_state({"value": 1, "value2": 2})
+    assert c_instance.read_state("value") == 1
+    assert c_instance.read_state("value2") == 2
+
+    # Test something that should fail
+    with pytest.raises(TypeError):
+        c_instance.update_state(1)
+
+    with pytest.raises(TypeError):
+        c_instance.update_state("Hello")
+
+    # Should do nothing
+    c_instance.update_state({})


### PR DESCRIPTION
Closes #164 

Doesn't add validate_state because that can be done in the `save_state` method.