### PR TITLE
Refactoring names away from infer and fit

### DIFF
--- a/docs/api/component-instance.md
+++ b/docs/api/component-instance.md
@@ -1,17 +1,17 @@
 ::: motion.ComponentInstance
-    handler: python
-    options:
-        members: 
-            - run
-            - arun
-            - read_state
-            - update_state
-            - flush_fit
-            - version
-            - shutdown
-            - instance_name
-        show_root_full_path: false
-        show_root_toc_entry: false
-        show_root_heading: true
-        show_source: false
-        show_signature_annotations: true
+handler: python
+options:
+  members:
+    - run
+    - arun
+    - read_state
+    - write_state
+    - flush_update
+    - version
+    - shutdown
+    - instance_name
+  show_root_full_path: false
+  show_root_toc_entry: false
+  show_root_heading: true
+  show_source: false
+  show_signature_annotations: true

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -1,18 +1,18 @@
 ::: motion.Component
-    handler: python
-    options:
-        members: 
-            - __init__
-            - infer 
-            - fit 
-            - init_state
-            - __call__
-            - save_state
-            - load_state
-            - name 
-            - params
-        show_root_full_path: false
-        show_root_toc_entry: false
-        show_root_heading: true
-        show_source: false
-        show_signature_annotations: true
+handler: python
+options:
+  members:
+    - **init**
+    - serve
+    - update
+    - init_state
+    - **call**
+    - save_state
+    - load_state
+    - name
+    - params
+  show_root_full_path: false
+  show_root_toc_entry: false
+  show_root_heading: true
+  show_source: false
+  show_signature_annotations: true

--- a/docs/tools/vis.md
+++ b/docs/tools/vis.md
@@ -23,15 +23,15 @@ def setUp():
     return {"mean": None, "std": None}
 
 
-@ZScoreComponent.infer("number")
+@ZScoreComponent.serve("number")
 def normalize(state, value):
     if state["mean"] is None:
         return None
     return abs(value - state["mean"]) / state["std"]
 
 
-@ZScoreComponent.fit("number", batch_size=10)
-def update(state, values, infer_results):
+@ZScoreComponent.update("number", batch_size=10)
+def update(state, values, serve_results):
     # We don't do anything with the results, but we could!
     mean = sum(values) / len(values)
     std = sum((n - mean) ** 2 for n in values) / len(values)
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     for i in range(9):
         print(c.run(number=i))
 
-    c.run(number=9, flush_fit=True)
+    c.run(number=9, flush_update=True)
     for i in range(10, 19):
         print(c.run(number=i))
 ```

--- a/ideas/roadmap.md
+++ b/ideas/roadmap.md
@@ -1,8 +1,8 @@
 # Roadmap
 
-- Remote fit operations
-- Remote infer operations
+- Remote update operations
+- Remote serve operations
 - State serialization
 - Observability/logging all inputs and outputs
 - Data validation on logged inputs/outputs
-- Trigger fit from data validation result, not just from batch size
+- Trigger update from data validation result, not just from batch size

--- a/motion/__init__.py
+++ b/motion/__init__.py
@@ -1,11 +1,11 @@
 from motion.component import Component
-from motion.utils import FitEventGroup, clear_instance, inspect_state
+from motion.utils import UpdateEventGroup, clear_instance, inspect_state
 from motion.instance import ComponentInstance
 from motion.migrate import StateMigrator
 
 __all__ = [
     "Component",
-    "FitEventGroup",
+    "UpdateEventGroup",
     "ComponentInstance",
     "clear_instance",
     "inspect_state",

--- a/motion/route.py
+++ b/motion/route.py
@@ -8,7 +8,9 @@ from motion.utils import logger
 
 class Route(BaseModel):
     key: str = Field(..., description="The keyword to which this route applies.")
-    op: str = Field(..., description="The operation to perform.", regex="^(infer|fit)$")
+    op: str = Field(
+        ..., description="The operation to perform.", regex="^(serve|update)$"
+    )
     udf: Callable = Field(
         ...,
         description="The udf to call for the op. The udf should have at least "

--- a/tests/component/test_bad_components.py
+++ b/tests/component/test_bad_components.py
@@ -3,19 +3,19 @@ from motion import Component
 import pytest
 
 
-def test_bad_infer_component():
+def test_bad_serve_component():
     with pytest.raises(ValueError):
-        c = Component("BadInferComponent")
+        c = Component("BadserveComponent")
 
         @c.init_state
         def setUp():
             return {"value": 0}
 
-        @c.infer("add")
+        @c.serve("add")
         def plus(state, value):
             return state["value"] + value
 
-        @c.infer("add")
+        @c.serve("add")
         def plus2(state, value):
             return state["value"] + value
 
@@ -28,17 +28,17 @@ def setUp():
     return {"value": 0}
 
 
-@c.fit("add")
-def plus(state, value, infer_result):
+@c.update("add")
+def plus(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
-@c.fit("add")
-def plus2(state, value, infer_result):
+@c.update("add")
+def plus2(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
-@c.infer("read")
+@c.serve("read")
 def read(state, value):
     return state["value"]
 
@@ -46,7 +46,7 @@ def read(state, value):
 def test_double_fit_component():
     c_instance = c()
 
-    c_instance.run("add", kwargs={"value": 1}, flush_fit=True)
+    c_instance.run("add", kwargs={"value": 1}, flush_update=True)
 
     assert c_instance.run("read", kwargs={"value": 2}) == 2
     c_instance.shutdown()

--- a/tests/component/test_counter.py
+++ b/tests/component/test_counter.py
@@ -9,13 +9,13 @@ def setUp():
     return {"value": 0}
 
 
-@Counter.infer("number")
+@Counter.serve("number")
 def noop(state, value):
     return state["value"], value
 
 
-@Counter.fit("number")
-def increment(state, value, infer_result):
+@Counter.update("number")
+def increment(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
@@ -25,9 +25,9 @@ def test_create():
     assert c.read_state("value") == 0
 
     assert c.run("number", kwargs={"value": 1})[1] == 1
-    c.run("number", kwargs={"value": 2}, flush_fit=True)
-    assert c.run("number", kwargs={"value": 3}, flush_fit=True)[1] == 3
-    assert c.run("number", kwargs={"value": 4}, flush_fit=True)[0] == 6
+    c.run("number", kwargs={"value": 2}, flush_update=True)
+    assert c.run("number", kwargs={"value": 3}, flush_update=True)[1] == 3
+    assert c.run("number", kwargs={"value": 4}, flush_update=True)[0] == 6
 
     # Should raise errors
     with pytest.raises(KeyError):
@@ -42,6 +42,6 @@ def test_create():
 def test_fit_error():
     c = Counter()
 
-    # Should raise error bc fit op won't work
+    # Should raise error bc update op won't work
     with pytest.raises(RuntimeError):
-        c.run("number", kwargs={"value": [1]}, flush_fit=True)
+        c.run("number", kwargs={"value": [1]}, flush_update=True)

--- a/tests/component/test_disabled_instance.py
+++ b/tests/component/test_disabled_instance.py
@@ -10,13 +10,13 @@ def setUp():
     return {"value": 0}
 
 
-@Counter.infer("number")
+@Counter.serve("number")
 def noop(state, value):
     return state["value"], value
 
 
-@Counter.fit("number")
-def increment(state, value, infer_result):
+@Counter.update("number")
+def increment(state, value, serve_result):
     return {"value": state["value"] + value}
 
 

--- a/tests/component/test_multiple_routes.py
+++ b/tests/component/test_multiple_routes.py
@@ -9,45 +9,45 @@ def setUp():
     return {"value": 0}
 
 
-@Calculator.infer("add")
+@Calculator.serve("add")
 def plus(state, value):
     return state["value"] + value
 
 
-@Calculator.fit("add")
-def increment(state, value, infer_result):
+@Calculator.update("add")
+def increment(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
-@Calculator.infer("subtract")
+@Calculator.serve("subtract")
 def minus(state, value):
     return state["value"] - value
 
 
-@Calculator.fit("subtract")
-def decrement(state, value, infer_result):
+@Calculator.update("subtract")
+def decrement(state, value, serve_result):
     return {"value": state["value"] - value}
 
 
-@Calculator.infer("identity")
+@Calculator.serve("identity")
 def noop(state, value):
     return value
 
 
-@Calculator.fit("reset")
-def reset(state, infer_result):
+@Calculator.update("reset")
+def reset(state, serve_result):
     return {"value": 0}
 
 
 def test_multiple_routes():
     c = Calculator()
-    assert c.run("add", kwargs={"value": 1}, flush_fit=True) == 1
-    assert c.run("add", kwargs={"value": 2}, flush_fit=True) == 3
-    assert c.run("subtract", kwargs={"value": 1}, flush_fit=True) == 2
+    assert c.run("add", kwargs={"value": 1}, flush_update=True) == 1
+    assert c.run("add", kwargs={"value": 2}, flush_update=True) == 3
+    assert c.run("subtract", kwargs={"value": 1}, flush_update=True) == 2
     assert c.run("identity", kwargs={"value": 1}) == 1
 
-    # Force fit doesn't do anything
-    c.run("identity", kwargs={"value": 1}, flush_fit=True)
+    # Force update doesn't do anything
+    c.run("identity", kwargs={"value": 1}, flush_update=True)
 
-    c.run("reset", flush_fit=True)
-    assert c.run("add", kwargs={"value": 1}, flush_fit=True) == 1
+    c.run("reset", flush_update=True)
+    assert c.run("add", kwargs={"value": 1}, flush_update=True) == 1

--- a/tests/component/test_params.py
+++ b/tests/component/test_params.py
@@ -10,20 +10,20 @@ def setUp():
     return {"value": 0}
 
 
-@c.infer("add")
+@c.serve("add")
 def plus(state, value):
     return c.params["multiplier"] * (state["value"] + value)
 
 
-@c.fit("add")
-def increment(state, value, infer_result):
+@c.update("add")
+def increment(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
 def test_params():
     c_instance = c()
-    assert c_instance.run("add", kwargs={"value": 1}, flush_fit=True) == 2
-    assert c_instance.run("add", kwargs={"value": 2}, flush_fit=True) == 6
+    assert c_instance.run("add", kwargs={"value": 1}, flush_update=True) == 2
+    assert c_instance.run("add", kwargs={"value": 2}, flush_update=True) == 6
 
 
 cwp = Component("ComponentWithoutParams")
@@ -34,19 +34,21 @@ def setUp2():
     return {"value": 0}
 
 
-@cwp.infer("add")
+@cwp.serve("add")
 def plus2(state, value):
     return cwp.params["multiplier"] * (state["value"] + value)
 
 
-@cwp.fit("add")
-def increment2(state, value, infer_result):
+@cwp.update("add")
+def increment2(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
 def test_params_not_exist():
     c_instance = cwp()
     with pytest.raises(KeyError):
-        assert c_instance.run("add", kwargs={"value": 1}, flush_fit=True) == 2
+        assert (
+            c_instance.run("add", kwargs={"value": 1}, flush_update=True) == 2
+        )
 
     c_instance.shutdown()

--- a/tests/parallel/test_async.py
+++ b/tests/parallel/test_async.py
@@ -11,24 +11,24 @@ def setup():
     return {"value": 1}
 
 
-@Counter.infer("multiply")
+@Counter.serve("multiply")
 async def noop(state, value):
     await asyncio.sleep(0.5)
     return state["value"] * value
 
 
-@Counter.infer("sync_multiply")
+@Counter.serve("sync_multiply")
 def sync_noop(state, value):
     return state["value"] * value
 
 
-@Counter.fit("multiply")
-async def increment(state, value, infer_result):
+@Counter.update("multiply")
+async def increment(state, value, serve_result):
     return {"value": state["value"] + 1}
 
 
 @pytest.mark.asyncio
-async def test_async_infer():
+async def test_async_serve():
     c = Counter()
     assert await c.arun("multiply", kwargs={"value": 2}) == 2
 
@@ -42,10 +42,10 @@ async def test_async_infer():
 
 
 @pytest.mark.asyncio
-async def test_async_fit():
+async def test_async_update():
     c = Counter()
 
-    await c.arun("multiply", kwargs={"value": 2}, flush_fit=True)
+    await c.arun("multiply", kwargs={"value": 2}, flush_update=True)
     assert c.read_state("value") == 2
 
 
@@ -62,7 +62,7 @@ async def test_gather():
     await asyncio.gather(*tasks)
 
     # Flush instance
-    c.flush_fit("multiply")
+    c.flush_update("multiply")
 
     # Assert new state
     assert c.read_state("value") == 101

--- a/tests/parallel/test_broken_fit.py
+++ b/tests/parallel/test_broken_fit.py
@@ -10,21 +10,21 @@ def setup():
     return {"value": 1}
 
 
-@Counter.infer("multiply")
+@Counter.serve("multiply")
 def noop(state, value):
     return state["value"] * value
 
 
-@Counter.fit("multiply")
-def increment(state, value, infer_result):
+@Counter.update("multiply")
+def increment(state, value, serve_result):
     print(state["does_not_exist"])  # This should break thread
     return {"value": state["value"] + 1}
 
 
-def test_release_lock_on_broken_fit():
+def test_release_lock_on_broken_update():
     c = Counter("same_id")
     with pytest.raises(RuntimeError):
-        c.run("multiply", kwargs={"value": 2}, flush_fit=True)
+        c.run("multiply", kwargs={"value": 2}, flush_update=True)
     c.shutdown()
 
     # Should be able to run again

--- a/tests/parallel/test_many_keys.py
+++ b/tests/parallel/test_many_keys.py
@@ -13,39 +13,39 @@ def setup():
     return {"value": 1, "multifit": []}
 
 
-@Counter.infer(["increment", "decrement"])
+@Counter.serve(["increment", "decrement"])
 def noop(state, value):
     return value
 
 
-@Counter.fit("increment")
-def increment(state, value, infer_result):
+@Counter.update("increment")
+def increment(state, value, serve_result):
     return {"value": state["value"] + 1}
 
 
-@Counter.fit("decrement")
-def nothing(state, value, infer_result):
+@Counter.update("decrement")
+def nothing(state, value, serve_result):
     return {"value": state["value"] - 1}
 
 
-@Counter.fit(["accumulate", "something_else"])
-def multifit(state, value, infer_result):
+@Counter.update(["accumulate", "something_else"])
+def multiupdate(state, value, serve_result):
     return {"multifit": state["multifit"] + [value]}
 
 
 def test_many_keys():
     c = Counter()
 
-    c.run("increment", kwargs={"value": 1}, flush_fit=True)
+    c.run("increment", kwargs={"value": 1}, flush_update=True)
     assert c.read_state("value") == 2
-    c.run("decrement", kwargs={"value": 1}, flush_fit=True)
+    c.run("decrement", kwargs={"value": 1}, flush_update=True)
     assert c.read_state("value") == 1
 
     # Test multifit
     c.run("accumulate", kwargs={"value": 1})
     c.run("something_else", kwargs={"value": 2})
 
-    c.flush_fit("accumulate")
-    c.flush_fit("something_else")
+    c.flush_update("accumulate")
+    c.flush_update("something_else")
 
     assert c.read_state("multifit") == [1, 2]

--- a/tests/parallel/test_two_instance.py
+++ b/tests/parallel/test_two_instance.py
@@ -8,19 +8,19 @@ def setup():
     return {"value": 1}
 
 
-@Counter.infer("multiply")
+@Counter.serve("multiply")
 def noop(state, value):
     return state["value"] * value
 
 
-@Counter.fit("multiply")
-def increment(state, value, infer_result):
+@Counter.update("multiply")
+def increment(state, value, serve_result):
     return {"value": state["value"] + 1}
 
 
 def test_redis_saving():
     inst1 = Counter(name="test")
-    assert inst1.run("multiply", kwargs={"value": 2}, flush_fit=True) == 2
+    assert inst1.run("multiply", kwargs={"value": 2}, flush_update=True) == 2
     assert inst1.read_state("value") == 2
     inst1.shutdown()
 
@@ -28,6 +28,6 @@ def test_redis_saving():
 
     inst2 = Counter(name="test")
     assert inst2.read_state("value") == 2
-    assert inst2.run("multiply", kwargs={"value": 3}, flush_fit=True) == 6
+    assert inst2.run("multiply", kwargs={"value": 3}, flush_update=True) == 6
     assert inst2.read_state("value") == 3
     inst2.shutdown()

--- a/tests/state/test_db_conn.py
+++ b/tests/state/test_db_conn.py
@@ -40,23 +40,23 @@ def load(state):
     return {"cursor": cursor, "fit_count": state["fit_count"]}
 
 
-@c.infer("count")
+@c.serve("count")
 def execute_fn(state, value):
     return state["cursor"].execute("SELECT COUNT(*) FROM users").fetchall()
 
 
-@c.infer("something")
+@c.serve("something")
 def noop(state, value):
     return state["fit_count"]
 
 
-@c.fit("something")
-def increment(state, value, infer_result):
+@c.update("something")
+def increment(state, value, serve_result):
     return {"fit_count": state["fit_count"] + 1}
 
 
 def test_db_component():
     c_instance = c()
     assert c_instance.run("count", kwargs={"value": 1}) == [(2,)]
-    c_instance.run("something", kwargs={"value": 1}, flush_fit=True)
+    c_instance.run("something", kwargs={"value": 1}, flush_update=True)
     assert c_instance.run("something", kwargs={"value": 5}) == 1

--- a/tests/state/test_flush_fit.py
+++ b/tests/state/test_flush_fit.py
@@ -8,16 +8,16 @@ def setUp():
     return {"value": 0, "values": []}
 
 
-@Counter.infer("number")
+@Counter.serve("number")
 def noop(state, value):
     return value
 
 
 # Arbitrarily large batch
-@Counter.fit("number")
-def increment(state, infer_result):
+@Counter.update("number")
+def increment(state, serve_result):
     values = state["values"]
-    values.append(infer_result)
+    values.append(serve_result)
 
     if len(values) == 10:
         return {"values": [], "value": sum(values) + state["value"]}
@@ -34,7 +34,7 @@ def test_flush_instance():
         counter.run("number", kwargs={"value": i})
 
     # Flush instance
-    counter.flush_fit("number")
+    counter.flush_update("number")
 
     # Assert new state is different from old state
     assert counter.get_version() > 1
@@ -42,8 +42,8 @@ def test_flush_instance():
     assert counter.read_state("value") == sum(range(10))
 
     # If I flush again, nothing should happen since
-    # there are no elements in the fit queue
-    counter.flush_fit("number")
+    # there are no elements in the update queue
+    counter.flush_update("number")
     assert counter.get_version() > 1
 
     counter.shutdown()
@@ -56,7 +56,7 @@ def test_fit_daemon():
         counter.run("number", kwargs={"value": i})
 
     # Flush instance
-    counter.flush_fit("number")
+    counter.flush_update("number")
 
     # Assert new state is different from old state
     assert counter.get_version() > 1

--- a/tests/state/test_model.py
+++ b/tests/state/test_model.py
@@ -19,15 +19,15 @@ def setUp():
     return {"model": model, "training_batch": []}
 
 
-@c.infer("value")
+@c.serve("value")
 def predict(state, value):
     return state["model"].predict([[value]])[0]
 
 
-@c.fit("value")
-def finetune(state, value, infer_result):
+@c.update("value")
+def finetune(state, value, serve_result):
     training_batch = state["training_batch"]
-    training_batch.append((value, infer_result))
+    training_batch.append((value, serve_result))
     if len(training_batch) < 2:
         return {"training_batch": training_batch}
 
@@ -46,7 +46,7 @@ def test_model_component():
     c_instance = c()
     first_run = c_instance.run("value", kwargs={"value": 1})
     assert first_run == c_instance.run(
-        "value", kwargs={"value": 1}, flush_fit=True
+        "value", kwargs={"value": 1}, flush_update=True
     )
 
     second_run = c_instance.run(
@@ -61,7 +61,7 @@ def test_ignore_cache():
     c_instance = c()
     first_run = c_instance.run("value", kwargs={"value": 1})
     assert first_run == c_instance.run(
-        "value", kwargs={"value": 1}, flush_fit=True
+        "value", kwargs={"value": 1}, flush_update=True
     )
 
     second_run = c_instance.run(

--- a/tests/state/test_write.py
+++ b/tests/state/test_write.py
@@ -10,27 +10,27 @@ def setUp():
     return {"value": 0}
 
 
-@C.infer("my_key")
-def infer(state):
+@C.serve("my_key")
+def serve(state):
     return state.instance_id
 
 
-def test_update_state():
+def test_write_state():
     c_instance = C()
     assert c_instance.read_state("value") == 0
-    c_instance.update_state({"value": 1, "value2": 2})
+    c_instance.write_state({"value": 1, "value2": 2})
     assert c_instance.read_state("value") == 1
     assert c_instance.read_state("value2") == 2
 
     # Test something that should fail
     with pytest.raises(TypeError):
-        c_instance.update_state(1)
+        c_instance.write_state(1)
 
     with pytest.raises(TypeError):
-        c_instance.update_state("Hello")
+        c_instance.write_state("Hello")
 
     # Should do nothing
-    c_instance.update_state({})
+    c_instance.write_state({})
 
 
 def test_read_instance_id():

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -19,13 +19,13 @@ def setup():
     return {"count": 0}
 
 
-@Test.infer("noop")
+@Test.serve("noop")
 async def noop(state, value):
     return value
 
 
-@Test.fit("increment")
-def noopfit(state, infer_result):
+@Test.update("increment")
+def noopupdate(state, serve_result):
     return {"count": state["count"] + 1}
 
 
@@ -37,7 +37,7 @@ def read_endpoint():
     # Create some instance of a component
     t = Test("testid")
     t.run("increment")
-    t.flush_fit("increment")
+    t.flush_update("increment")
 
     return {"value": t.read_state("count")}
 

--- a/tests/test_simple_pipeline.py
+++ b/tests/test_simple_pipeline.py
@@ -9,13 +9,13 @@ def setUp():
     return {"value": 0}
 
 
-@a.infer("add")
+@a.serve("add")
 def plus(state, value):
     return state["value"] + value
 
 
-@a.fit("add")
-def increment(state, value, infer_result):
+@a.update("add")
+def increment(state, value, serve_result):
     return {"value": state["value"] + value}
 
 
@@ -27,24 +27,24 @@ def setUp():
     return {"message": ""}
 
 
-@b.infer("concat")
+@b.serve("concat")
 def concat_message(state, str_to_concat):
     return state["message"] + " " + str_to_concat
 
 
-@b.fit("concat")
-def update_message(state, str_to_concat, infer_result):
+@b.update("concat")
+def update_message(state, str_to_concat, serve_result):
     return {"message": state["message"] + " " + str_to_concat}
 
 
 def test_simple_pipeline():
     a_instance = a()
     b_instance = b()
-    add_result = a_instance.run("add", kwargs={"value": 1}, flush_fit=True)
+    add_result = a_instance.run("add", kwargs={"value": 1}, flush_update=True)
     assert add_result == 1
 
     concat_result = b_instance.run(
-        "concat", kwargs={"str_to_concat": str(add_result)}, flush_fit=True
+        "concat", kwargs={"str_to_concat": str(add_result)}, flush_update=True
     )
     assert concat_result == " 1"
 


### PR DESCRIPTION
## Description

This PR refactors the codebase to use `serve` instead of `infer` and `update` instead of `fit`.

## Related Issues

Closes #208 

## Checklist

Please make sure that you have completed the following items before submitting this pull request:

- [x] Code is up-to-date with the main branch
- [x] Code has been tested locally and all tests pass
- [x] Code changes have been documented (if necessary)
- [x] Code changes adhere to the project's coding standards
- [x] Any necessary new dependencies have been added to the project's `pyproject.toml` file

## Screenshots

[Add any relevant screenshots or images to help illustrate the changes in this pull request.]

## Additional Notes

[Add any additional information or context that you feel is important for reviewers to know about this pull request.]
