### PR TITLE
Committing first pass of application code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
     services:
       redis:
         image: redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9, 3.10, 3.11]
     services:
       redis:
         image: redis
@@ -27,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ site*
 *package-lock.json
 projects
 unnecessary.py
+motionstate*
+*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist*
 site*
 *package-lock.json
 projects
+unnecessary.py

--- a/docs/api/application.md
+++ b/docs/api/application.md
@@ -1,0 +1,15 @@
+::: motion.server.Application
+    handler: python
+    options:
+        members:
+            - __init__
+            - create_read_state_endpoint
+            - create_write_state_endpoint
+            - create_component_endpoint
+            - get_app
+            - get_credentials
+        show_root_full_path: false
+        show_root_toc_entry: false
+        show_root_heading: true
+        show_source: false
+        show_signature_annotations: true

--- a/docs/examples/application.md
+++ b/docs/examples/application.md
@@ -1,0 +1,123 @@
+# Building a Motion Application
+
+In this tutorial, we'll go through setting up an application of Motion components. We'll go through setting up a simple server with custom components and then demonstrate how to interact with it using Axios in a TypeScript environment.
+
+## Prerequisites
+
+- [Motion](/motion/getting-started/installation/)
+- [FastAPI](https://fastapi.tiangolo.com/) -- installed automatically with Motion
+- [uvicorn](https://www.uvicorn.org/) -- To serve the application
+
+## Step 1: Define Some Components
+
+We'll write two components: one representing a counter, and another representing a calculator. The counter will increment a count every time an operation is called. The calculator will add and subtract two numbers.
+
+```python title="sample_components.py" linenums="1"
+from motion import Component
+
+Counter = Component("Counter")
+
+@Counter.init_state
+def setup():
+    return {"count": 0}
+
+@Counter.serve("increment")
+def increment(state, props):
+    return state["count"] + 1
+
+@Counter.update("increment")
+def update_count(state, props):
+    return {"count": state["count"] + 1}
+
+Calculator = Component("Calculator")
+
+@Calculator.serve("add")
+def add(state, props):
+    return props["a"] + props["b"]
+
+@Calculator.serve("subtract")
+def subtract(state, props):
+    return props["a"] - props["b"]
+```
+
+## Step 2: Create an Application
+
+We'll create an application that serves the two components we just defined.
+
+```python title="app.py" linenums="1"
+# app.py
+from motion.server import Application
+from sample_components import Counter, Calculator
+import uvicorn
+
+# Create the Motion application with both components
+motion_app = Application(components=[Counter, Calculator])
+fastapi_app = motion_app.get_app()
+
+# Run the application using Uvicorn
+if __name__ == "__main__":
+    # Print secret key
+    print(motion_app.get_credentials())
+
+    uvicorn.run(fastapi_app, host="0.0.0.0", port=8000)
+```
+
+In the script, we include a statement to print the secret key (which is useful if you don't specify your secret key and Motion automatically creates one for your application). Keep this key safe, as it is used to authenticate requests to the application.
+
+To run the application, we can run `python app.py` in the terminal. We can also run `uvicorn app:fastapi_app --reload` to run the application with hot reloading.
+
+One of the powerful features of FastAPI is its automatic generation of interactive API documentation. Once your server is running, you can access the API documentation by visiting `http://localhost:8000/docs` in your web browser. This documentation provides a detailed overview of all the available routes (i.e., the Counter and Calculator component dataflows) and allows you to directly test the API endpoints from the browser.
+
+## Step 3: Interact with the Application
+
+Suppose we are in TypeScript and want to interact with the application. We can use Axios to make requests to the application. First, install Axios in your web application:
+
+```bash
+npm install axios
+```
+
+Then, we can write a simple Typescript function to make requests to the application:
+
+```typescript title="queryMotionApp.ts" linenums="1"
+import axios from "axios";
+
+const queryServer = async () => {
+  const secretToken = "your_secret_key"; // Replace with the secret key from your Motion application
+
+  try {
+    // Increment the Counter
+    const incrementResponse = await axios.post(
+      "http://localhost:8000/Counter",
+      {
+        instance_id: "ts_testid",
+        dataflow_key: "increment",
+        props: {},
+      },
+      {
+        headers: { Authorization: `Bearer ${secretToken}` },
+      }
+    );
+    console.log("Counter Increment Result:", incrementResponse.data);
+
+    // Perform an addition using the Calculator
+    const addResponse = await axios.post(
+      "http://localhost:8000/Calculator",
+      {
+        instance_id: "ts_testid",
+        dataflow_key: "add",
+        props: { a: 20, b: 10 },
+      },
+      {
+        headers: { Authorization: `Bearer ${secretToken}` },
+      }
+    );
+    console.log("Addition Result:", addResponse.data);
+  } catch (error) {
+    console.error("Error querying server:", error);
+  }
+};
+
+queryServer();
+```
+
+Since the application is served as a REST API, we can also use any other HTTP client to interact with the application.

--- a/docs/examples/application.md
+++ b/docs/examples/application.md
@@ -46,7 +46,7 @@ We'll create an application that serves the two components we just defined.
 
 ```python title="app.py" linenums="1"
 # app.py
-from motion.server import Application
+from motion import Application
 from sample_components import Counter, Calculator
 import uvicorn
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,11 +11,13 @@ nav:
   - Examples:
       - Hello World: examples/hello-world.md
       - Common Design Patterns: examples/design-patterns.md
+      - Orchestrating an Application of Components: examples/application.md
       - Querying Data with Natural Language: examples/nl-query.md
   - API Reference:
       - Component: api/component.md
       - ComponentInstance: api/component-instance.md
       - Props and State: api/props-and-state.md
+      - Application: api/application.md
       - StateMigrator: api/state-migrator.md
   - Helpful Tools:
       - Component Visualization: tools/vis.md

--- a/motion/__init__.py
+++ b/motion/__init__.py
@@ -10,7 +10,6 @@ from motion.instance import ComponentInstance
 from motion.migrate import StateMigrator
 from motion.dicts import MDataFrame
 from motion.copy_utils import copy_db
-from motion.server.application import Application
 
 __all__ = [
     "Component",
@@ -23,5 +22,4 @@ __all__ = [
     "MDataFrame",
     "copy_db",
     "RedisParams",
-    "Application",
 ]

--- a/motion/__init__.py
+++ b/motion/__init__.py
@@ -10,6 +10,7 @@ from motion.instance import ComponentInstance
 from motion.migrate import StateMigrator
 from motion.dicts import MDataFrame
 from motion.copy_utils import copy_db
+from motion.server.application import Application
 
 __all__ = [
     "Component",
@@ -22,4 +23,5 @@ __all__ = [
     "MDataFrame",
     "copy_db",
     "RedisParams",
+    "Application",
 ]

--- a/motion/instance.py
+++ b/motion/instance.py
@@ -428,7 +428,7 @@ class ComponentInstance:
 
         Raises:
             ValueError: If more than one dataflow key-value pair is passed.
-            If flush_update is called and the component instance update
+                If flush_update is called and the component instance update
                 processes are disabled.
 
         Returns:

--- a/motion/server/__init__.py
+++ b/motion/server/__init__.py
@@ -1,3 +1,0 @@
-from motion.server.application import Application
-
-__all__ = ["Application"]

--- a/motion/server/__init__.py
+++ b/motion/server/__init__.py
@@ -1,0 +1,3 @@
+from motion.server.application import Application
+
+__all__ = ["Application"]

--- a/motion/server/application.py
+++ b/motion/server/application.py
@@ -1,0 +1,188 @@
+"""This file creates a FastAPI application instance for a group of components."""
+
+import secrets
+from typing import Any, Dict, List
+
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Request
+from pydantic import BaseModel, validator
+
+from motion.component import Component
+
+
+# Pydantic model for request payload
+class RunRequest(BaseModel):
+    instance_id: str
+    dataflow_key: str
+    async_action: bool = False
+    props: Dict[str, Any]
+    run_kwargs: Dict[str, Any] = {}  # kwargs to pass to the run method
+    creation_kwargs: Dict[str, Any] = {}  # kwargs to pass to component creation
+
+    @validator("props")
+    def validate_props(cls, v):
+        if not isinstance(v, dict):
+            raise ValueError("Props must be a dictionary")
+        return v
+
+
+class UpdateStateRequest(BaseModel):
+    instance_id: str
+    state_update: Dict[str, Any]
+    kwargs: Dict[str, Any]
+
+
+# Authentication dependency
+def api_key_auth(secret_token: str):
+    def validate_api_key(request: Request):
+        if "Authorization" not in request.headers:
+            raise HTTPException(
+                status_code=401, detail="No Authorization header provided"
+            )
+
+        api_key = request.headers["Authorization"].split("Bearer ")[-1]
+        expected_key = f"{secret_token}"
+        if secrets.compare_digest(api_key, expected_key):
+            return True
+        else:
+            raise HTTPException(
+                status_code=403, detail="Could not validate credentials"
+            )
+
+    return validate_api_key
+
+
+# Application class
+class Application:
+    def __init__(
+        self,
+        components: List[Component],
+        secret_token: str = None,
+    ):
+        self.app = FastAPI()
+        self.components = components
+        self.secret_token = (
+            secret_token if secret_token else "sk_" + str(secrets.token_urlsafe(32))
+        )
+        self._generate_routes()
+
+    def _generate_routes(self):
+        for component in self.components:
+            component_name = component.name
+            endpoint = self.create_component_endpoint(component)
+            route = f"/{component_name}"
+            self.app.post(route)(endpoint)
+
+            update_route = f"/{component_name}/update"
+            read_route = f"/{component_name}/read"
+
+            self.app.post(update_route)(self.create_update_state_endpoint(component))
+            self.app.get(read_route)(self.create_read_state_endpoint(component))
+
+    def create_read_state_endpoint(self, component):
+        async def read_state_endpoint(
+            instance_id: str,
+            key: str,
+            _=Depends(api_key_auth(self.secret_token)),
+        ):
+            try:
+                with component(
+                    instance_id, disable_update_task=True
+                ) as component_instance:
+                    value = component_instance.read_state(key)
+                    # Return as JSON
+                    return {key: value}
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
+
+        return read_state_endpoint
+
+    def create_update_state_endpoint(self, component):
+        async def update_state_endpoint(
+            request: UpdateStateRequest,
+            _=Depends(api_key_auth(self.secret_token)),
+        ):
+            instance_id = request.instance_id
+            state_update = request.state_update
+            kwargs = request.kwargs
+
+            # Assuming you have a method in your Component class to handle state updates
+            try:
+                with component(
+                    instance_id, disable_update_task=True
+                ) as component_instance:
+                    component_instance.update_state(state_update, **kwargs)
+                    return {
+                        "status": "success",
+                        "message": "State updated successfully.",
+                    }
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=str(e))
+
+        return update_state_endpoint
+
+    def create_component_endpoint(self, component):
+        async def endpoint(
+            request: RunRequest,
+            background_tasks: BackgroundTasks,
+            _=Depends(api_key_auth(self.secret_token)),
+        ) -> Any:
+            instance_id = request.instance_id
+            dataflow_key = request.dataflow_key
+            async_action = request.async_action
+            props = request.props
+            run_kwargs = request.run_kwargs
+            creation_kwargs = request.creation_kwargs
+
+            # Validate that the action is correct
+            component_instance = None
+            try:
+                component_instance = component(instance_id, **creation_kwargs)
+
+                # Run the relevant action
+                if async_action:
+                    result = await component_instance.arun(
+                        dataflow_key=dataflow_key, props=props, **run_kwargs
+                    )
+
+                else:
+                    result = component_instance.run(
+                        dataflow_key=dataflow_key, props=props, **run_kwargs
+                    )
+
+                # Add flush update task to background
+                if run_kwargs.get("flush_update", False):
+                    background_tasks.add_task(
+                        component_instance.flush_update,
+                        **{"dataflow_key": dataflow_key},
+                    )
+
+                background_tasks.add_task(component_instance.shutdown)
+
+                # Return direct result
+                return result
+
+            except Exception as e:
+                if component_instance:
+                    background_tasks.add_task(component_instance.shutdown)
+                raise HTTPException(status_code=500, detail=str(e))
+
+        return endpoint
+
+    def get_app(self):
+        return self.app
+
+    def get_credentials(self):
+        return {"secret_token": self.secret_token}
+
+
+# Example usage
+# app_instance = Application(components=[ComponentA, ComponentB])
+# credentials = app_instance.get_credentials()
+# app = app_instance.get_app()
+
+# # Credentials are instance-specific and not global
+# print("Credentials for this instance of the app:")
+# print(credentials)
+
+# To run the app, use uvicorn as follows:
+# uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/motion/server/update_task.py
+++ b/motion/server/update_task.py
@@ -39,7 +39,7 @@ class BaseUpdateTask:
         self.daemon = True
 
         self.redis_params = redis_params
-        self.redis_con = None
+        self.redis_con: Optional[redis.Redis] = None
 
     def __del__(self) -> None:
         if self.redis_con is not None:

--- a/motion/server/update_task.py
+++ b/motion/server/update_task.py
@@ -38,12 +38,15 @@ class BaseUpdateTask:
         self.running = running
         self.daemon = True
 
-        self.redis_con = redis.Redis(**redis_params)
+        self.redis_params = redis_params
+        self.redis_con = None
 
     def __del__(self) -> None:
-        self.redis_con.close()
+        if self.redis_con is not None:
+            self.redis_con.close()
 
     def custom_run(self) -> None:
+        self.redis_con = redis.Redis(**self.redis_params)
         redis_con = self.redis_con
 
         while self.running.value:

--- a/tests/server/test_simple_server.py
+++ b/tests/server/test_simple_server.py
@@ -43,7 +43,7 @@ def test_endpoint(client):
         json={
             "instance_id": "testid",
             "dataflow_key": "sum",
-            "async_action": False,
+            "is_async": False,
             "props": {"values": [1, 2, 3]},
         },
         headers={"Authorization": f"Bearer {credentials['secret_token']}"},

--- a/tests/server/test_simple_server.py
+++ b/tests/server/test_simple_server.py
@@ -64,16 +64,3 @@ def test_endpoint(client):
 
     assert response.status_code == 200
     assert response.json() == {"multiplier": 2}
-
-
-# Example usage
-# app_instance = Application(components=[ComponentA, ComponentB])
-# credentials = app_instance.get_credentials()
-# app = app_instance.get_app()
-
-# # Credentials are instance-specific and not global
-# print("Credentials for this instance of the app:")
-# print(credentials)
-
-# To run the app, use uvicorn as follows:
-# uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/server/test_simple_server.py
+++ b/tests/server/test_simple_server.py
@@ -1,7 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from motion import Component, Application
+from motion import Component
+from motion.server.application import Application
 
 # Create some components
 

--- a/tests/server/test_simple_server.py
+++ b/tests/server/test_simple_server.py
@@ -1,0 +1,78 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from motion import Component, Application
+
+# Create some components
+
+Counter = Component("Counter")
+
+
+@Counter.init_state
+def setup():
+    return {"multiplier": 1}
+
+
+@Counter.serve("sum")
+def compute_sum(state, props):
+    return sum(props["values"]) * state["multiplier"]
+
+
+@Counter.update("sum")
+def update_sum(state, props):
+    return {"multiplier": state["multiplier"] + 1}
+
+
+@pytest.fixture
+def client():
+    # Create application
+    motion_app = Application(components=[Counter])
+    credentials = motion_app.get_credentials()
+    app = motion_app.get_app()
+
+    return credentials, TestClient(app)
+
+
+def test_endpoint(client):
+    credentials, client = client  # Unpack
+
+    # Test the run endpoint
+    response = client.post(
+        "/Counter",
+        json={
+            "instance_id": "testid",
+            "dataflow_key": "sum",
+            "async_action": False,
+            "props": {"values": [1, 2, 3]},
+        },
+        headers={"Authorization": f"Bearer {credentials['secret_token']}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == 6
+
+    # Read the state and check that it was updated
+    response = client.get(
+        "/Counter/read",
+        params={
+            "instance_id": "testid",
+            "key": "multiplier",
+        },
+        headers={"Authorization": f"Bearer {credentials['secret_token']}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"multiplier": 2}
+
+
+# Example usage
+# app_instance = Application(components=[ComponentA, ComponentB])
+# credentials = app_instance.get_credentials()
+# app = app_instance.get_app()
+
+# # Credentials are instance-specific and not global
+# print("Credentials for this instance of the app:")
+# print(credentials)
+
+# To run the app, use uvicorn as follows:
+# uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/tests/server/test_simple_server.py
+++ b/tests/server/test_simple_server.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from motion import Component
-from motion.server.application import Application
+from motion import Application
 
 # Create some components
 


### PR DESCRIPTION
## Description

This PR adds a feature to build a FastAPI server on top of a motion application. For example:

```python
# Example usage
from motion.server import Application

app_instance = Application(components=[ComponentA, ComponentB])
credentials = app_instance.get_credentials()
app = app_instance.get_app()

# Credentials are instance-specific and not global
print("Credentials for this instance of the app:")
print(credentials)

# To run the app, use uvicorn as follows:
uvicorn.run(app, host="0.0.0.0", port=8000)
```
  
Remaining to-dos:
- [x] Write documentation for `Application` class
- [x] Write a tutorial on how to set up and call an application

## Related Issues

Closes #259 

## Checklist

Please make sure that you have completed the following items before submitting this pull request:

- [ ] Code is up-to-date with the main branch
- [ ] Code has been tested locally and all tests pass
- [ ] Code changes have been documented (if necessary)
- [ ] Code changes adhere to the project's coding standards
- [ ] Any necessary new dependencies have been added to the project's `pyproject.toml` file

## Screenshots

[Add any relevant screenshots or images to help illustrate the changes in this pull request.]

## Additional Notes

[Add any additional information or context that you feel is important for reviewers to know about this pull request.]
