### PR TITLE
Raising errors when migrations fail to update state

### DIFF
--- a/motion/migrate.py
+++ b/motion/migrate.py
@@ -37,7 +37,17 @@ def process_migration(
             {},
         )
         empty_state.update(new_state)
-        _ = saveState(empty_state, version, redis_con, instance_name, save_state_fn)
+        success_indicator = saveState(
+            empty_state, version, redis_con, instance_name, save_state_fn
+        )
+
+        if success_indicator == -1:
+            # Migration failed because the state was updated in the meantime
+            raise AssertionError(
+                f"Migration failed for {instance_name} because the "
+                + "state was updated by another process in the meantime."
+            )
+
     except Exception as e:
         if isinstance(e, AssertionError):
             raise e

--- a/motion/migrate.py
+++ b/motion/migrate.py
@@ -43,7 +43,7 @@ def process_migration(
 
         if success_indicator == -1:
             # Migration failed because the state was updated in the meantime
-            raise AssertionError(
+            raise RuntimeError(
                 f"Migration failed for {instance_name} because the "
                 + "state was updated by another process in the meantime."
             )


### PR DESCRIPTION
Now that we have stronger concurrency guarantees (last-write-wins), migrations may fail if the state updates during the migration of an instance. This PR includes raises a runtime error indicating failure for such instances.