### PR TITLE
Support generators in serve ops

### DIFF
--- a/docs/api/component-instance.md
+++ b/docs/api/component-instance.md
@@ -4,6 +4,8 @@
         members:
             - run
             - arun
+            - gen
+            - agen
             - read_state
             - write_state
             - flush_update

--- a/docs/examples/design-patterns.md
+++ b/docs/examples/design-patterns.md
@@ -3,3 +3,4 @@
 - Caching results to save cost (wrapper around OpenAI LLM)
 - Disabled component instances
 - Context manager component instances
+- Generator UDFs (e.g., for streaming LLM output)

--- a/motion/component.py
+++ b/motion/component.py
@@ -507,9 +507,13 @@ class Component:
         if __name__ == "__main__":
             c_instance = MyComponent(init_state_params={"starting_val": 3})
             c_instance.run(..)
+            c_instance.shutdown()
         ```
 
-        You can also use component instances as context managers:
+        You can also use component instances as context managers,
+        which is the recommended way to use them (because it will
+        automatically gracefully shut down the component instance
+        when the context manager exits):
         ```python
         ...
         if __name__ == "__main__":

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -6,7 +6,17 @@ import os
 import threading
 import types
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple
+from typing import (
+    Any,
+    AsyncGenerator,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+)
 from uuid import uuid4
 
 import cloudpickle
@@ -538,7 +548,7 @@ class Executor:
         ignore_cache: bool,
         force_refresh: bool,
         flush_update: bool,
-    ) -> Iterable[Any]:
+    ) -> Generator[Any, None, None]:
         route_hit = False
         serve_result = None
         is_generated = False
@@ -622,7 +632,7 @@ class Executor:
         ignore_cache: bool,
         force_refresh: bool,
         flush_update: bool,
-    ) -> Iterable[Any]:
+    ) -> AsyncGenerator[Any, None]:
         route_hit = False
         serve_result = None
         props = Properties(props)

--- a/motion/instance.py
+++ b/motion/instance.py
@@ -299,7 +299,7 @@ class ComponentInstance:
 
         self._executor.flush_update(dataflow_key)
 
-    def iter(
+    def gen(
         self,
         dataflow_key: str,
         props: Dict[str, Any] = {},
@@ -395,14 +395,14 @@ class ComponentInstance:
         """
 
         serve_result = []
-        for elem in self.iter(
+        for elem in self.gen(
             dataflow_key, props, ignore_cache, force_refresh, flush_update
         ):
             serve_result.append(elem)
 
         return serve_result[0]
 
-    async def aiter(
+    async def agen(
         self,
         dataflow_key: str,
         props: Dict[str, Any] = {},
@@ -482,7 +482,7 @@ class ComponentInstance:
         # Run agen and collect the results into a list
         results = []
 
-        async for elem in self.aiter(
+        async for elem in self.agen(
             dataflow_key, props, ignore_cache, force_refresh, flush_update
         ):
             results.append(elem)

--- a/tests/parallel/test_generator.py
+++ b/tests/parallel/test_generator.py
@@ -1,0 +1,93 @@
+"""
+This file tests the generator and async generator functionality.
+"""
+import pytest
+from motion import Component
+
+C = Component("GeneratorComponent")
+
+
+@C.init_state
+def setUp():
+    return {"value": 1}
+
+
+@C.serve("identity")
+def identity(state, props):
+    values = props["values"]
+
+    # Return an iterator over the props values
+    for v in values:
+        yield v
+
+
+@C.update("identity")
+def assert_list(state, props):
+    # Add serve result to state
+    return {"sync_serve_result": props.serve_result}
+
+
+@C.serve("async_identity")
+async def async_identity(state, props):
+    values = props["values"]
+
+    # Return an iterator over the props values
+    for v in values:
+        yield v
+
+
+@C.update("async_identity")
+async def async_assert_list(state, props):
+    # Add serve result to state
+    return {"async_serve_result": props.serve_result}
+
+
+def test_regular_generator():
+    c = C("some_instance")
+    values = [1, 2, 3]
+
+    serve_values = []
+    for v in c.gen("identity", props={"values": values}, flush_update=True):
+        serve_values.append(v)
+    assert serve_values == values
+
+    assert c.read_state("sync_serve_result") == values
+    c.shutdown()
+
+    # Open the instance again and read the cached result
+    c = C("some_instance")
+    assert c.read_state("sync_serve_result") == values
+
+    serve_values = []
+    for v in c.gen("identity", props={"values": values}):
+        serve_values.append(v)
+    assert serve_values == values, "Cached result should be returned"
+
+    c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_async_generator():
+    c = C("some_async_instance")
+    values = [4, 5, 6]
+
+    serve_values = []
+    async for v in c.agen(
+        "async_identity", props={"values": values}, flush_update=True
+    ):
+        serve_values.append(v)
+    assert serve_values == values
+
+    assert c.read_state("async_serve_result") == values
+    c.shutdown()
+
+    # Open the instance again and read the cached result
+    c = C("some_async_instance")
+    assert c.read_state("async_serve_result") == values
+
+    serve_values = []
+    async for v in c.agen("async_identity", props={"values": values}):
+        serve_values.append(v)
+    assert serve_values == values, "Cached result should be returned"
+
+    c.shutdown()


### PR DESCRIPTION
## Description

This PR introduces the `gen` and `agen` component instance methods, which allow users to define serve ops that are generator functions. We also add 2 tests to make sure that even when generated results are cached, motion returns the results as the expected iterable.

## Related Issues

Closes #283 
