### PR TITLE
Handling backpressure for update ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,29 @@
 [![GitHub tag](https://img.shields.io/github/tag/dm4ml/motion?include_prereleases=&sort=semver&color=blue)](https://github.com/dm4ml/motion/releases/)
 [![PyPI version](https://badge.fury.io/py/motion-python.svg?branch=main&kill_cache=1)](https://badge.fury.io/py/motion-python)
 
-Motion is a **Python framework** for incrementally maintaining prompts and other LLM pipeline state as new data arrives. Motion components are **stateful** and **incremental**, and can be run anywhere (e.g., in a notebook, in a serverless function, in a web app) because they are backed by a key-value store.
+Motion is a system for defining and incrementally maintaining **reactive prompts** in Python.
+
+## Why Reactive Prompts?
+
+LLM accuracy often significantly improves with more context. Consider an e-commerce focused LLM pipeline that recommends products to users. The recommendations might improve if the prompt considers the user's past purchases and browsing history. Ideally, any new information about the user (e.g., a new purchase or browsing event) should be incorporated into the LLM pipeline's prompts as soon as possible; thus, we call them **reactive prompts**.
+
+### Why is it Hard to Use Reactive Prompts?
+
+Consider the e-commerce example above. The prompt might grow to be very long---so long that there's a bunch of redundant or event useless information in the prompt. So, we might want to summarize the user's past purchases and browsing history into a single prompt. However, summarizing the user's past purchases and browsing history every time we log a new purchase or browsing event, or whenever the user requests a new recommendation, **can take too long** and thus prohibitively increase end-to-end latency for getting a recommendation.
+
+In general, we may want to use LLMs or run some other expensive operation when incrementally processing new information, e.g., through summarization, extracting structured information, or generating new data. When there is a lot of information to process, the best LLMs can take upwards of 30 seconds. This can be unacceptable for production latency.
+
+## What is Motion?
+
+As LLM pipeline developers, we want a few things when building and using reactive prompts:
+
+- **Flexibility**: We want to be able to define our sub-parts of prompts (e.g., summaries). We also want to be able to define our own logic for how to turn sub-parts into string prompts and reactively update sub-parts.
+- **Availability**: We want there to always be some version of prompt sub-parts available, even if they are a little stale. This way we can minimize end-to-end latency.
+- **Freshness**: Prompts should incorporate as much of the latest information as possible. In the case where information arrives faster than we can process it, it may be desirable to ignore older information.
+
+Motion allows LLM pipeline developers to define and incrementally maintain reactive prompts in Python. With Motion, we define **components** that represent prompt sub-parts, and **flows** that represent how to assemble sub-parts into a prompt for an LLM in real-time and how to reactively update sub-parts in the background based on new information.
+
+Motion's execution engine serves cached prompt sub-parts for minimal real-time latency and handles concurrency and sub-part consistency when running flows that update sub-parts. All prompt sub-parts are backed by a key-value store. You can run Motion components anywhere and in any number of Python processes (e.g., in a notebook, in a serverless function, in a web server) at the same time for maximal availability.
 
 ## An Example Motion Component
 
@@ -66,11 +88,9 @@ Multiple clients can run flows on the same component instance, and the state of 
 
 ## Should I use Motion?
 
-Motion is especially useful for applications that:
+Motion is especially useful for LLM pipelines
 
-- Need to update prompts based on new data (e.g., maintain a dynamic list of examples in the prompt)
-- Need to continually fine-tune models or do any online learning
-- Want to maintain state across multiple requests
+- Need to update prompts based on new data (e.g., maintain a dynamic summary in the prompt)
 - Want a Pythonic interface to build a distributed system of LLM application components
 
 Motion is built for developers who know how to code in Python and want to be able to control operations in their ML applications. For low-code and domain-specific development patterns (e.g., enhancing videos), you may want to check out other tools.

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -1,18 +1,27 @@
 ::: motion.Component
-handler: python
-options:
-members: - **init** - serve - update - init_state - **call** - save_state - load_state - name - params
-show_root_full_path: false
-show_root_toc_entry: false
-show_root_heading: true
-show_source: false
-show_signature_annotations: true
+    handler: python
+    options:
+        members:
+            - __init__
+            - serve
+            - update
+            - init_state
+            - __call__
+            - save_state
+            - load_state
+            - name
+            - params
+        show_root_full_path: false
+        show_root_toc_entry: false
+        show_root_heading: true
+        show_source: false
+        show_signature_annotations: true
 
-::: motion.DiscardPolicy
-handler: python
-options:
-show_root_full_path: false
-show_root_toc_entry: true
-show_root_heading: true
-show_source: false
-show_signature_annotations: true
+::: motion.UpdateDiscardPolicy
+    handler: python
+    options:
+        show_root_full_path: false
+        show_root_toc_entry: true
+        show_root_heading: true
+        show_source: false
+        show_signature_annotations: true

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -1,27 +1,18 @@
 ::: motion.Component
-    handler: python
-    options:
-        members:
-            - __init__
-            - serve
-            - update
-            - init_state
-            - __call__
-            - save_state
-            - load_state
-            - name
-            - params
-        show_root_full_path: false
-        show_root_toc_entry: false
-        show_root_heading: true
-        show_source: false
-        show_signature_annotations: true
+handler: python
+options:
+members: - **init** - serve - update - init_state - **call** - save_state - load_state - name - params
+show_root_full_path: false
+show_root_toc_entry: false
+show_root_heading: true
+show_source: false
+show_signature_annotations: true
 
-::: motion.ExpirePolicy
-    handler: python
-    options:
-        show_root_full_path: false
-        show_root_toc_entry: true
-        show_root_heading: true
-        show_source: false
-        show_signature_annotations: true
+::: motion.DiscardPolicy
+handler: python
+options:
+show_root_full_path: false
+show_root_toc_entry: true
+show_root_heading: true
+show_source: false
+show_signature_annotations: true

--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -16,3 +16,12 @@
         show_root_heading: true
         show_source: false
         show_signature_annotations: true
+
+::: motion.ExpirePolicy
+    handler: python
+    options:
+        show_root_full_path: false
+        show_root_toc_entry: true
+        show_root_heading: true
+        show_source: false
+        show_signature_annotations: true

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -22,12 +22,12 @@ Since serve operations do not modify the state, you can run multiple serve opera
 
 Motion's execution engine experiences backpressure if a queue of pending update operations grows faster than the rate at which its update operations are completed. For example, if an update operation calls an LLM for a long prompt and takes 10 seconds to complete, and new update operations are being added to the queue every second, the queue will grow by 10 operations every second. While this does not pose problems for serve operations because serve operations can read stale state, it can cause the component instance to fall behind in processing update operations.
 
-Our solution to limit queue growth is to offer a configurable `ExpirePolicy` parameter for each update operation. There are two options for `ExpirePolicy`:
+Our solution to limit queue growth is to offer a configurable `DiscardPolicy` parameter for each update operation. There are two options for `DiscardPolicy`:
 
-- `ExpirePolicy.SECONDS`: If more than `expire_after` seconds have passed since the update operation _u_ was added to the queue, _u_ is removed from the queue and the state is not updated with _u_'s results.
-- `ExpirePolicy.NUM_NEW_UPDATES`: If more than `expire_after` new update operations have been added to the queue since an update operation _u_ was added, _u_ is removed from the queue and the state is not updated with _u_'s results.
+- `DiscardPolicy.SECONDS`: If more than `discard_after` seconds have passed since the update operation _u_ was added to the queue, _u_ is removed from the queue and the state is not updated with _u_'s results.
+- `DiscardPolicy.NUM_NEW_UPDATES`: If more than `discard_after` new update operations have been added to the queue since an update operation _u_ was added, _u_ is removed from the queue and the state is not updated with _u_'s results.
 
-See the [API docs](/motion/api/component/#motion.ExpirePolicy) for how to use `ExpirePolicy`.
+See the [API docs](/motion/api/component/#motion.DiscardPolicy) for how to use `DiscardPolicy`.
 
 ## State vs Props
 
@@ -42,8 +42,8 @@ On the other hand, props are passed in at runtime and are only available to the 
 - Components can have many flows, each with their own key, serve operation, and update operation(s).
 - Components can only have one serve operation per key.
 - The `serve` operation is run on the main thread, while the `update` operation is run in the background. You directly get access to `serve` results, but `update` results are not accessible unless you read values from the state dictionary.
-- `serve` results are cached, with a default expiration time of 24 hours. If you run a component twice on the same flow key-value pair, the second run will return the result of the first run. To override the caching behavior, see the [API docs](/motion/api/component-instance/#motion.instance.ComponentInstance.run).
-- `update` operations are processed sequentially in first-in-first-out (FIFO) order. This allows state to be updated incrementally. To handle backpressure, update operations can be configured to expire after a certain amount of time or after a certain number of new update operations have been added to the queue. See the [API docs](/motion/api/component/#motion.ExpirePolicy) for how to use `ExpirePolicy`.
+- `serve` results are cached, with a default discard time of 24 hours. If you run a component twice on the same flow key-value pair, the second run will return the result of the first run. To override the caching behavior, see the [API docs](/motion/api/component-instance/#motion.instance.ComponentInstance.run).
+- `update` operations are processed sequentially in first-in-first-out (FIFO) order. This allows state to be updated incrementally. To handle backpressure, update operations can be configured to expire after a certain amount of time or after a certain number of new update operations have been added to the queue. See the [API docs](/motion/api/component/#motion.DiscardPolicy) for how to use `DiscardPolicy`.
 
 ## Example Component
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,38 @@
 # Welcome to Motion
 
-Motion is a **Python framework** for incrementally maintaining prompts and other LLM pipeline state as new data arrives. Motion components are **stateful** and **incremental**, and can be run anywhere (e.g., in a notebook, in a serverless function, in a web app) because they are backed by a key-value store.
+Motion is a system for defining and incrementally maintaining **reactive prompts** in Python.
 
 !!! tip "Alpha Release"
 
     Motion is currently in alpha. We are actively working on improving the documentation and adding more features. If you are interested in using Motion and would like dedicated support from one of our team members, please reach out to us at [shreyashankar@berkeley.edu](mailto:shreyashankar@berkeley.edu).
 
+## Why Reactive Prompts?
+
+LLM accuracy often significantly improves with more context. Consider an e-commerce focused LLM pipeline that recommends products to users. The recommendations might improve if the prompt considers the user's past purchases and browsing history. Ideally, any new information about the user (e.g., a new purchase or browsing event) should be incorporated into the LLM pipeline's prompts as soon as possible; thus, we call them **reactive prompts**.
+
+### Why is it Hard to Use Reactive Prompts?
+
+Consider the e-commerce example above. The prompt might grow to be very long---so long that there's a bunch of redundant or event useless information in the prompt. So, we might want to summarize the user's past purchases and browsing history into a single prompt. However, summarizing the user's past purchases and browsing history every time we log a new purchase or browsing event, or whenever the user requests a new recommendation, **can take too long** and thus prohibitively increase end-to-end latency for getting a recommendation.
+
+In general, we may want to use LLMs or run some other expensive operation when incrementally processing new information, e.g., through summarization, extracting structured information, or generating new data. When there is a lot of information to process, the best LLMs can take upwards of 30 seconds. This can be unacceptable for production latency.
+
+## What is Motion?
+
+As LLM pipeline developers, we want a few things when building and using reactive prompts:
+
+- **Flexibility**: We want to be able to define our sub-parts of prompts (e.g., summaries). We also want to be able to define our own logic for how to turn sub-parts into string prompts and reactively update sub-parts.
+- **Availability**: We want there to always be some version of prompt sub-parts available, even if they are a little stale. This way we can minimize end-to-end latency.
+- **Freshness**: Prompts should incorporate as much of the latest information as possible. In the case where information arrives faster than we can process it, it may be desirable to ignore older information.
+
+Motion allows LLM pipeline developers to define and incrementally maintain reactive prompts in Python. With Motion, we define **components** that represent prompt sub-parts, and **flows** that represent how to assemble sub-parts into a prompt for an LLM in real-time and how to reactively update sub-parts in the background based on new information.
+
+Motion's execution engine serves cached prompt sub-parts for minimal real-time latency and handles concurrency and sub-part consistency when running flows that update sub-parts. All prompt sub-parts are backed by a key-value store. You can run Motion components anywhere and in any number of Python processes (e.g., in a notebook, in a serverless function, in a web server) at the same time for maximal availability.
+
 ## Should I use Motion?
 
-Motion is especially useful for applications that:
+Motion is especially useful for LLM pipelines
 
-- Need to update prompts based on new data (e.g., maintain a dynamic list of examples in the prompt)
-- Need to continually fine-tune models or do any online learning
-- Want to maintain state across multiple requests
+- Need to update prompts based on new data (e.g., maintain a dynamic summary in the prompt)
 - Want a Pythonic interface to build a distributed system of LLM application components
 
 Motion is built for developers who know how to code in Python and want to be able to control operations in their ML applications. For low-code and domain-specific development patterns (e.g., enhancing videos), you may want to check out other tools.

--- a/motion/__init__.py
+++ b/motion/__init__.py
@@ -10,7 +10,7 @@ from motion.utils import (
 from motion.instance import ComponentInstance
 from motion.migrate import StateMigrator
 from motion.copy_utils import copy_db
-from motion.expire_policy import ExpirePolicy
+from motion.discard_policy import DiscardPolicy
 
 __all__ = [
     "Component",
@@ -22,7 +22,7 @@ __all__ = [
     "get_instances",
     "copy_db",
     "RedisParams",
-    "ExpirePolicy",
+    "DiscardPolicy",
 ]
 
 # Conditionally import Application

--- a/motion/__init__.py
+++ b/motion/__init__.py
@@ -10,6 +10,7 @@ from motion.utils import (
 from motion.instance import ComponentInstance
 from motion.migrate import StateMigrator
 from motion.copy_utils import copy_db
+from motion.expire_policy import ExpirePolicy
 
 __all__ = [
     "Component",
@@ -21,6 +22,7 @@ __all__ = [
     "get_instances",
     "copy_db",
     "RedisParams",
+    "ExpirePolicy",
 ]
 
 # Conditionally import Application

--- a/motion/component.py
+++ b/motion/component.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from motion.dicts import Params
-from motion.expire_policy import ExpirePolicy, validate_policy
+from motion.discard_policy import DiscardPolicy, validate_policy
 from motion.instance import ComponentInstance
 from motion.route import Route
 from motion.utils import (
@@ -385,8 +385,8 @@ class Component:
     def update(
         self,
         keys: Union[str, List[str]],
-        expire_policy: ExpirePolicy = ExpirePolicy.NONE,
-        expire_after: Optional[int] = None,
+        discard_policy: DiscardPolicy = DiscardPolicy.NONE,
+        discard_after: Optional[int] = None,
     ) -> Any:
         """Decorator for any update operations for flows through the
         component. Takes in a string or list of strings that represents the
@@ -405,7 +405,7 @@ class Component:
         multiple update ops. Update functions should return a dictionary
         of state updates to be merged with the current state.
 
-        See `ExpirePolicy` for more info on how to expire update operations if
+        See `DiscardPolicy` for more info on how to expire update operations if
         you expect there to be backpressure for an update operation.
 
         Example Usage:
@@ -448,9 +448,9 @@ class Component:
         Args:
             keys (Union[str, List[str]]): String or list of strings that
                 represent the input keyword(s) for the update flow.
-            expire_policy (ExpirePolicy, optional): Policy for expiring
-                update operations. Defaults to ExpirePolicy.NONE.
-            expire_after (Optional[int], optional): Number of updates
+            discard_policy (DiscardPolicy, optional): Policy for expiring
+                update operations. Defaults to DiscardPolicy.NONE.
+            discard_after (Optional[int], optional): Number of updates
                 or seconds after which to expire the update operation.
                 Defaults to None.
 
@@ -475,11 +475,11 @@ class Component:
                 )
 
             # Raises error if invalid expire policy
-            validate_policy(expire_policy, expire_after)
+            validate_policy(discard_policy, discard_after)
 
             func._op = "update"  # type: ignore
-            func._expire_policy = expire_policy  # type: ignore
-            func._expire_after = expire_after  # type: ignore
+            func._discard_policy = discard_policy  # type: ignore
+            func._discard_after = discard_after  # type: ignore
 
             for key in keys:
                 self.add_route(key, func._op, func)  # type: ignore

--- a/motion/component.py
+++ b/motion/component.py
@@ -405,6 +405,9 @@ class Component:
         multiple update ops. Update functions should return a dictionary
         of state updates to be merged with the current state.
 
+        See `ExpirePolicy` for more info on how to expire update operations if
+        you expect there to be backpressure for an update operation.
+
         Example Usage:
         ```python
         from motion import Component
@@ -445,6 +448,11 @@ class Component:
         Args:
             keys (Union[str, List[str]]): String or list of strings that
                 represent the input keyword(s) for the update flow.
+            expire_policy (ExpirePolicy, optional): Policy for expiring
+                update operations. Defaults to ExpirePolicy.NONE.
+            expire_after (Optional[int], optional): Number of updates
+                or seconds after which to expire the update operation.
+                Defaults to None.
 
         Returns:
             Callable: Decorated update function.

--- a/motion/discard_policy.py
+++ b/motion/discard_policy.py
@@ -1,33 +1,33 @@
 """
-This file contains expiration policies for update queues.
+This file contains discard policies for update queues.
 """
 
 from enum import Enum
 from typing import Optional
 
 
-class ExpirePolicy(Enum):
+class DiscardPolicy(Enum):
     """
-    Defines the policy for expiring items in an update operation's queue.
+    Defines the policy for discarding items in an update operation's queue.
     Each component instance has a queue for each update operation. Items in
     the queue are processed in first-in-first-out (FIFO) order, and items
-    in the queue can expire based on the expiration policy set by the
+    in the queue can delete based on the discard policy set by the
     developer.
 
     Attributes:
-        NONE: Indicates no expiration policy. Items in the queue do not expire.
-        NUM_NEW_UPDATES: Items expire based on the number of new updates. Once
+        NONE: Indicates no discard policy. Items in the queue do not delete.
+        NUM_NEW_UPDATES: Items delete based on the number of new updates. Once
             the number of new updates exceeds a certain threshold, the oldest
             items are removed.
-        SECONDS: Items expire based on time. Items older than a specified
-            number of seconds are removed.
+        SECONDS: Items delete based on time. Items older than a specified
+            number of seconds at the time of processing are removed.
 
-    Use the `expire_after` and `expire_policy` arguments in `Component.update`
-    decorator to set the expiration policy for an update operation.
+    Use the `discard_after` and `discard_policy` arguments in `Component.update`
+    decorator to set the discard policy for an update operation.
 
     Example Usage:
     ```python
-    from motion import Component, ExpirePolicy
+    from motion import Component, DiscardPolicy
 
     C = Component("C")
 
@@ -37,15 +37,15 @@ class ExpirePolicy(Enum):
 
     @C.update(
         "something",
-        expire_after=10,
-        expire_policy=ExpirePolicy.NUM_NEW_UPDATES
+        discard_after=10,
+        discard_policy=DiscardPolicy.NUM_NEW_UPDATES
     )
     def update_num_new(state, props):
         # Do an expensive operation that could take a while
         ...
         return {"some_value": state["some_value"] + props["value"]}
 
-    @C.update("something", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+    @C.update("something", discard_after=1, discard_policy=DiscardPolicy.SECONDS)
     def update_seconds(state, props):
         # Do an expensive operation that could take a while
         ...
@@ -78,38 +78,38 @@ class ExpirePolicy(Enum):
         c.shutdown()
     ```
 
-    1. The default policy is to not expire any items (ExpirePolicy.NONE), so
+    1. The default policy is to not delete any items (DiscardPolicy.NONE), so
     the value of `default_value` will be the sum of all the values passed to
     `run` (i.e., `sum(range(100))`).
 
-    2. The NUM_NEW_UPDATES policy will expire items in the queue once the
+    2. The NUM_NEW_UPDATES policy will delete items in the queue once the
     number of new updates exceeds a certain threshold. The threshold is set by
-    the `expire_after` argument in the `update` decorator. So the result will
-    be < 4950 because the NUM_NEW_UPDATES policy will have expired some items.
+    the `discard_after` argument in the `update` decorator. So the result will
+    be < 4950 because the NUM_NEW_UPDATES policy will have deleted some items.
 
-    3. This will be < 4950 because the SECONDS policy will have expired some
+    3. This will be < 4950 because the SECONDS policy will have deleted some
     items (only whatever updates could have been processed in the second after
     they were added to the queue).
     """
 
     NONE = 0
-    """ No expiration policy. """
+    """ No discard policy. Does not discard items in the queue. """
 
     NUM_NEW_UPDATES = 1
-    """ Expire items based on the number of new updates. """
+    """ Delete items based on the number of new updates enqueued. """
 
     SECONDS = 2
-    """ Expire items based on time (in seconds). """
+    """ Delete items based on time (in seconds). """
 
 
-def validate_policy(policy: ExpirePolicy, expire_after: Optional[int]) -> None:
-    if policy == ExpirePolicy.NONE:
-        if expire_after is not None:
-            raise ValueError("expire_after must be None for policy NONE")
+def validate_policy(policy: DiscardPolicy, discard_after: Optional[int]) -> None:
+    if policy == DiscardPolicy.NONE:
+        if discard_after is not None:
+            raise ValueError("discard_after must be None for policy NONE")
         return
 
-    if expire_after is None:
-        raise ValueError("expire_after must be set for policy != NONE")
+    if discard_after is None:
+        raise ValueError("discard_after must be set for policy != NONE")
 
-    if expire_after <= 0:
-        raise ValueError("expire_after must be > 0")
+    if discard_after <= 0:
+        raise ValueError("discard_after must be > 0")

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -431,10 +431,10 @@ class Executor:
                     # If the func has a expire_after attribute, expire_at
                     # = current time + expire_after
                     expire_at = (
-                        self._redis_con.time()[0] + func._expire_after
-                        if func._expire_policy == ExpirePolicy.SECONDS
+                        self._redis_con.time()[0] + func._expire_after  # type: ignore
+                        if func._expire_policy == ExpirePolicy.SECONDS  # type: ignore
                         else None
-                    )
+                    )  # type: ignore
 
                     # Add to update queue
                     self._redis_con.rpush(
@@ -450,21 +450,21 @@ class Executor:
 
                     # If the func has a expire_after attribute, delete
                     # old items in a queue
-                    if func._expire_after is not None:
-                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:
+                    if func._expire_after is not None:  # type: ignore
+                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
                             # Get the length of the queue
                             queue_length = self._redis_con.llen(queue_identifier)
                             # If the queue length is greater than the
                             # expire_after attribute, delete the oldest
                             # (queue_length - expire_after) items
-                            if queue_length > func._expire_after:
+                            if queue_length > func._expire_after:  # type: ignore
                                 self._redis_con.ltrim(
                                     queue_identifier,
-                                    queue_length - func._expire_after,
+                                    queue_length - func._expire_after,  # type: ignore
                                     -1,
                                 )
 
-                        elif func._expire_policy == ExpirePolicy.SECONDS:
+                        elif func._expire_policy == ExpirePolicy.SECONDS:  # type: ignore # noqa: E501
                             # Need to delete items that are older than
                             # expire_after seconds
                             # Can just do this in the update task
@@ -534,8 +534,8 @@ class Executor:
                     # If the func has a expire_after attribute, expire_at
                     # = current time + expire_after
                     expire_at = (
-                        self._redis_con.time()[0] + func._expire_after
-                        if func._expire_policy == ExpirePolicy.SECONDS
+                        self._redis_con.time()[0] + func._expire_after  # type: ignore
+                        if func._expire_policy == ExpirePolicy.SECONDS  # type: ignore
                         else None
                     )
 
@@ -553,21 +553,21 @@ class Executor:
 
                     # If the func has a expire_after attribute, delete
                     # old items in a queue
-                    if func._expire_after is not None:
-                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:
+                    if func._expire_after is not None:  # type: ignore
+                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
                             # Get the length of the queue
                             queue_length = self._redis_con.llen(queue_identifier)
                             # If the queue length is greater than the
                             # expire_after attribute, delete the oldest
                             # (queue_length - expire_after) items
-                            if queue_length > func._expire_after:
+                            if queue_length > func._expire_after:  # type: ignore
                                 self._redis_con.ltrim(
                                     queue_identifier,
-                                    queue_length - func._expire_after,
+                                    queue_length - func._expire_after,  # type: ignore
                                     -1,
                                 )
 
-                        elif func._expire_policy == ExpirePolicy.SECONDS:
+                        elif func._expire_policy == ExpirePolicy.SECONDS:  # type: ignore # noqa: E501
                             # Need to delete items that are older than
                             # expire_after seconds
                             # Can just do this in the update task

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -798,7 +798,7 @@ class Executor:
             update_events.add(update_udf_name, update_event)
 
             # Add to update queue
-            self._redis_con.lpush(
+            self._redis_con.rpush(
                 queue_identifier,
                 cloudpickle.dumps(
                     {

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -334,6 +334,10 @@ class Executor:
 
         self.monitor_thread.join()
 
+        # Delete self.running
+        self.running = None
+        del self.running
+
     def _updateState(
         self,
         new_state: Dict[str, Any],

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -728,7 +728,7 @@ class Executor:
             update_events.add(update_udf_name, update_event)
 
             # Add to update queue
-            self._redis_con.rpush(
+            self._redis_con.lpush(
                 queue_identifier,
                 cloudpickle.dumps(
                     {

--- a/motion/execute.py
+++ b/motion/execute.py
@@ -24,7 +24,7 @@ import psutil
 import redis
 
 from motion.dicts import Properties, State
-from motion.expire_policy import ExpirePolicy
+from motion.discard_policy import DiscardPolicy
 from motion.route import Route
 from motion.server.update_task import UpdateProcess, UpdateThread
 from motion.utils import (
@@ -428,11 +428,11 @@ class Executor:
 
                     identifier = str(uuid4())
 
-                    # If the func has a expire_after attribute, expire_at
-                    # = current time + expire_after
+                    # If the func has a discard_after attribute, expire_at
+                    # = current time + discard_after
                     expire_at = (
-                        self._redis_con.time()[0] + func._expire_after  # type: ignore
-                        if func._expire_policy == ExpirePolicy.SECONDS  # type: ignore
+                        self._redis_con.time()[0] + func._discard_after  # type: ignore
+                        if func._discard_policy == DiscardPolicy.SECONDS  # type: ignore
                         else None
                     )  # type: ignore
 
@@ -448,25 +448,25 @@ class Executor:
                         ),
                     )
 
-                    # If the func has a expire_after attribute, delete
+                    # If the func has a discard_after attribute, delete
                     # old items in a queue
-                    if func._expire_after is not None:  # type: ignore
-                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
+                    if func._discard_after is not None:  # type: ignore
+                        if func._discard_policy == DiscardPolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
                             # Get the length of the queue
                             queue_length = self._redis_con.llen(queue_identifier)
                             # If the queue length is greater than the
-                            # expire_after attribute, delete the oldest
-                            # (queue_length - expire_after) items
-                            if queue_length > func._expire_after:  # type: ignore
+                            # discard_after attribute, delete the oldest
+                            # (queue_length - discard_after) items
+                            if queue_length > func._discard_after:  # type: ignore
                                 self._redis_con.ltrim(
                                     queue_identifier,
-                                    queue_length - func._expire_after,  # type: ignore
+                                    queue_length - func._discard_after,  # type: ignore
                                     -1,
                                 )
 
-                        elif func._expire_policy == ExpirePolicy.SECONDS:  # type: ignore # noqa: E501
+                        elif func._discard_policy == DiscardPolicy.SECONDS:  # type: ignore # noqa: E501
                             # Need to delete items that are older than
-                            # expire_after seconds
+                            # discard_after seconds
                             # Can just do this in the update task
                             pass
 
@@ -531,11 +531,11 @@ class Executor:
 
                     identifier = str(uuid4())
 
-                    # If the func has a expire_after attribute, expire_at
-                    # = current time + expire_after
+                    # If the func has a discard_after attribute, expire_at
+                    # = current time + discard_after
                     expire_at = (
-                        self._redis_con.time()[0] + func._expire_after  # type: ignore
-                        if func._expire_policy == ExpirePolicy.SECONDS  # type: ignore
+                        self._redis_con.time()[0] + func._discard_after  # type: ignore
+                        if func._discard_policy == DiscardPolicy.SECONDS  # type: ignore
                         else None
                     )
 
@@ -551,25 +551,25 @@ class Executor:
                         ),
                     )
 
-                    # If the func has a expire_after attribute, delete
+                    # If the func has a discard_after attribute, delete
                     # old items in a queue
-                    if func._expire_after is not None:  # type: ignore
-                        if func._expire_policy == ExpirePolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
+                    if func._discard_after is not None:  # type: ignore
+                        if func._discard_policy == DiscardPolicy.NUM_NEW_UPDATES:  # type: ignore # noqa: E501
                             # Get the length of the queue
                             queue_length = self._redis_con.llen(queue_identifier)
                             # If the queue length is greater than the
-                            # expire_after attribute, delete the oldest
-                            # (queue_length - expire_after) items
-                            if queue_length > func._expire_after:  # type: ignore
+                            # discard_after attribute, delete the oldest
+                            # (queue_length - discard_after) items
+                            if queue_length > func._discard_after:  # type: ignore
                                 self._redis_con.ltrim(
                                     queue_identifier,
-                                    queue_length - func._expire_after,  # type: ignore
+                                    queue_length - func._discard_after,  # type: ignore
                                     -1,
                                 )
 
-                        elif func._expire_policy == ExpirePolicy.SECONDS:  # type: ignore # noqa: E501
+                        elif func._discard_policy == DiscardPolicy.SECONDS:  # type: ignore # noqa: E501
                             # Need to delete items that are older than
-                            # expire_after seconds
+                            # discard_after seconds
                             # Can just do this in the update task
                             pass
 

--- a/motion/expire_policy.py
+++ b/motion/expire_policy.py
@@ -1,0 +1,24 @@
+"""
+This file contains expiration policies for update queues.
+"""
+
+from enum import Enum
+
+
+class ExpirePolicy(Enum):
+    NONE = 0
+    NUM_NEW_UPDATES = 1
+    SECONDS = 2
+
+
+def validate_policy(policy: ExpirePolicy, expire_after: int) -> None:
+    if policy == ExpirePolicy.NONE:
+        if expire_after is not None:
+            raise ValueError("expire_after must be None for policy NONE")
+        return
+
+    if expire_after is None:
+        raise ValueError("expire_after must be set for policy != NONE")
+
+    if expire_after <= 0:
+        raise ValueError("expire_after must be > 0")

--- a/motion/expire_policy.py
+++ b/motion/expire_policy.py
@@ -3,6 +3,7 @@ This file contains expiration policies for update queues.
 """
 
 from enum import Enum
+from typing import Optional
 
 
 class ExpirePolicy(Enum):
@@ -11,7 +12,7 @@ class ExpirePolicy(Enum):
     SECONDS = 2
 
 
-def validate_policy(policy: ExpirePolicy, expire_after: int) -> None:
+def validate_policy(policy: ExpirePolicy, expire_after: Optional[int]) -> None:
     if policy == ExpirePolicy.NONE:
         if expire_after is not None:
             raise ValueError("expire_after must be None for policy NONE")

--- a/motion/expire_policy.py
+++ b/motion/expire_policy.py
@@ -7,9 +7,99 @@ from typing import Optional
 
 
 class ExpirePolicy(Enum):
+    """
+    Defines the policy for expiring items in an update operation's queue.
+    Each component instance has a queue for each update operation. Items in
+    the queue are processed in first-in-first-out (FIFO) order, and items
+    in the queue can expire based on the expiration policy set by the
+    developer.
+
+    Attributes:
+        NONE: Indicates no expiration policy. Items in the queue do not expire.
+        NUM_NEW_UPDATES: Items expire based on the number of new updates. Once
+            the number of new updates exceeds a certain threshold, the oldest
+            items are removed.
+        SECONDS: Items expire based on time. Items older than a specified
+            number of seconds are removed.
+
+    Use the `expire_after` and `expire_policy` arguments in `Component.update`
+    decorator to set the expiration policy for an update operation.
+
+    Example Usage:
+    ```python
+    from motion import Component, ExpirePolicy
+
+    C = Component("C")
+
+    @C.init_state
+    def setup():
+        return {"default_value": 0, "some_value": 0, "another_value": 0}
+
+    @C.update(
+        "something",
+        expire_after=10,
+        expire_policy=ExpirePolicy.NUM_NEW_UPDATES
+    )
+    def update_num_new(state, props):
+        # Do an expensive operation that could take a while
+        ...
+        return {"some_value": state["some_value"] + props["value"]}
+
+    @C.update("something", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+    def update_seconds(state, props):
+        # Do an expensive operation that could take a while
+        ...
+        return {"another_value": state["another_value"] + props["value"]}
+
+    @C.update("something")
+    def update_default(state, props):
+        # Do an expensive operation that could take a while
+        ...
+        return {"default_value": state["default_value"] + props["value"]}
+
+    if __name__ == "__main__":
+        c = C()
+
+        # If we do many runs of "something", the update queue will grow
+        # and the policy will be automatically enforced by Motion.
+
+        for i in range(100):
+            c.run("something", props={"value": str(i)})
+
+        # Flush the update queue (i.e., wait for all updates to finish)
+        c.flush_update("something")
+
+        print(c.read_state("default_value")) # (1)!
+
+        print(c.read_state("some_value")) # (2)!
+
+        print(c.read_state("another_value")) # (3)!
+
+        c.shutdown()
+    ```
+
+    1. The default policy is to not expire any items (ExpirePolicy.NONE), so
+    the value of `default_value` will be the sum of all the values passed to
+    `run` (i.e., `sum(range(100))`).
+
+    2. The NUM_NEW_UPDATES policy will expire items in the queue once the
+    number of new updates exceeds a certain threshold. The threshold is set by
+    the `expire_after` argument in the `update` decorator. So the result will
+    be < 4950 because the NUM_NEW_UPDATES policy will have expired some items.
+
+    3. This will be < 4950 because the SECONDS policy will have expired some
+    items (only whatever updates could have been processed in the second after
+    they were added to the queue).
+    """
+
     NONE = 0
+    """ No expiration policy. """
+
     NUM_NEW_UPDATES = 1
+    """ Expire items based on the number of new updates. """
+
     SECONDS = 2
+    """ Expire items based on time (in seconds). """
 
 
 def validate_policy(policy: ExpirePolicy, expire_after: Optional[int]) -> None:

--- a/motion/mtable.py
+++ b/motion/mtable.py
@@ -174,7 +174,6 @@ class MTable:
                 identifier = self._prefix + "/" + identifier
 
             identifier = identifier + ".parquet"
-            print(identifier)
             pq.write_table(self.data, identifier, filesystem=self.filesystem)
             return {
                 "identifier": identifier,

--- a/motion/server/update_task.py
+++ b/motion/server/update_task.py
@@ -56,7 +56,7 @@ class BaseUpdateTask:
             queue_name = ""
             try:
                 # for _ in range(self.batch_size):
-                full_item = redis_con.brpop(self.queue_identifiers, timeout=0.01)
+                full_item = redis_con.blpop(self.queue_identifiers, timeout=0.01)
                 if full_item is None:
                     if not self.running.value:
                         break  # no more items in the list

--- a/motion/server/update_task.py
+++ b/motion/server/update_task.py
@@ -56,7 +56,7 @@ class BaseUpdateTask:
             queue_name = ""
             try:
                 # for _ in range(self.batch_size):
-                full_item = redis_con.blpop(self.queue_identifiers, timeout=0.1)
+                full_item = redis_con.brpop(self.queue_identifiers, timeout=0.1)
                 if full_item is None:
                     if not self.running.value:
                         break  # no more items in the list

--- a/poetry.lock
+++ b/poetry.lock
@@ -3030,29 +3030,29 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.0.261"
-description = "An extremely fast Python linter, written in Rust."
+version = "0.1.14"
+description = "An extremely fast Python linter and code formatter, written in Rust."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.261-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:6624a966c4a21110cee6780333e2216522a831364896f3d98f13120936eff40a"},
-    {file = "ruff-0.0.261-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:2dba68a9e558ab33e6dd5d280af798a2d9d3c80c913ad9c8b8e97d7b287f1cc9"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8dbd0cee5a81b0785dc0feeb2640c1e31abe93f0d77c5233507ac59731a626f1"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:581e64fa1518df495ca890a605ee65065101a86db56b6858f848bade69fc6489"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc970f6ece0b4950e419f0252895ee42e9e8e5689c6494d18f5dc2c6ebb7f798"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8fa98e747e0fe185d65a40b0ea13f55c492f3b5f9a032a1097e82edaddb9e52e"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f268d52a71bf410aa45c232870c17049df322a7d20e871cfe622c9fc784aab7b"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d1293acc64eba16a11109678dc4743df08c207ed2edbeaf38b3e10eb2597321b"},
-    {file = "ruff-0.0.261-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d95596e2f4cafead19a6d1ec0b86f8fda45ba66fe934de3956d71146a87959b3"},
-    {file = "ruff-0.0.261-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4bcec45abdf65c1328a269cf6cc193f7ff85b777fa2865c64cf2c96b80148a2c"},
-    {file = "ruff-0.0.261-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6c5f397ec0af42a434ad4b6f86565027406c5d0d0ebeea0d5b3f90c4bf55bc82"},
-    {file = "ruff-0.0.261-py3-none-musllinux_1_2_i686.whl", hash = "sha256:39abd02342cec0c131b2ddcaace08b2eae9700cab3ca7dba64ae5fd4f4881bd0"},
-    {file = "ruff-0.0.261-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:aaa4f52a6e513f8daa450dac4859e80390d947052f592f0d8e796baab24df2fc"},
-    {file = "ruff-0.0.261-py3-none-win32.whl", hash = "sha256:daff64b4e86e42ce69e6367d63aab9562fc213cd4db0e146859df8abc283dba0"},
-    {file = "ruff-0.0.261-py3-none-win_amd64.whl", hash = "sha256:0fbc689c23609edda36169c8708bb91bab111d8f44cb4a88330541757770ab30"},
-    {file = "ruff-0.0.261-py3-none-win_arm64.whl", hash = "sha256:d2eddc60ae75fc87f8bb8fd6e8d5339cf884cd6de81e82a50287424309c187ba"},
-    {file = "ruff-0.0.261.tar.gz", hash = "sha256:c1c715b0d1e18f9c509d7c411ca61da3543a4aa459325b1b1e52b8301d65c6d2"},
+    {file = "ruff-0.1.14-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:96f76536df9b26622755c12ed8680f159817be2f725c17ed9305b472a757cdbb"},
+    {file = "ruff-0.1.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab3f71f64498c7241123bb5a768544cf42821d2a537f894b22457a543d3ca7a9"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7060156ecc572b8f984fd20fd8b0fcb692dd5d837b7606e968334ab7ff0090ab"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a53d8e35313d7b67eb3db15a66c08434809107659226a90dcd7acb2afa55faea"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bea9be712b8f5b4ebed40e1949379cfb2a7d907f42921cf9ab3aae07e6fba9eb"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2270504d629a0b064247983cbc495bed277f372fb9eaba41e5cf51f7ba705a6a"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80258bb3b8909b1700610dfabef7876423eed1bc930fe177c71c414921898efa"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:653230dd00aaf449eb5ff25d10a6e03bc3006813e2cb99799e568f55482e5cae"},
+    {file = "ruff-0.1.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87b3acc6c4e6928459ba9eb7459dd4f0c4bf266a053c863d72a44c33246bfdbf"},
+    {file = "ruff-0.1.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6b3dadc9522d0eccc060699a9816e8127b27addbb4697fc0c08611e4e6aeb8b5"},
+    {file = "ruff-0.1.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1c8eca1a47b4150dc0fbec7fe68fc91c695aed798532a18dbb1424e61e9b721f"},
+    {file = "ruff-0.1.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:62ce2ae46303ee896fc6811f63d6dabf8d9c389da0f3e3f2bce8bc7f15ef5488"},
+    {file = "ruff-0.1.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2027dde79d217b211d725fc833e8965dc90a16d0d3213f1298f97465956661b"},
+    {file = "ruff-0.1.14-py3-none-win32.whl", hash = "sha256:722bafc299145575a63bbd6b5069cb643eaa62546a5b6398f82b3e4403329cab"},
+    {file = "ruff-0.1.14-py3-none-win_amd64.whl", hash = "sha256:e3d241aa61f92b0805a7082bd89a9990826448e4d0398f0e2bc8f05c75c63d99"},
+    {file = "ruff-0.1.14-py3-none-win_arm64.whl", hash = "sha256:269302b31ade4cde6cf6f9dd58ea593773a37ed3f7b97e793c8594b262466b67"},
+    {file = "ruff-0.1.14.tar.gz", hash = "sha256:ad3f8088b2dfd884820289a06ab718cde7d38b94972212cc4ba90d5fbc9955f3"},
 ]
 
 [[package]]
@@ -3703,4 +3703,4 @@ table = ["fastvs", "pandas", "pyarrow"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "2f5967e20ad7214d7c0096f3ade5f8331bd24cb272095c8b3bac177af7ca52c8"
+content-hash = "309d1e779ce245abec9a0f940143c20b06aebcdbe63e554cd691b203d8ad1fff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "motion-python"
-version = "0.1.120"
+version = "0.1.121"
 description = "A trigger-based framework for creating and executing ML pipelines."
 authors = ["Shreya Shankar <shreyashankar@berkeley.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "motion-python"
-version = "0.1.121"
+version = "0.1.122"
 description = "A trigger-based framework for creating and executing ML pipelines."
 authors = ["Shreya Shankar <shreyashankar@berkeley.edu>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ mkdocs-material = "^9.1.5"
 mkdocstrings = {version="^0.20.0", extras = ["python"] }
 pytkdocs = "^0.16.1"
 linkchecker = "^10.2.1"
-ruff = "^0.0.261"
 maturin = "^0.14.17"
 mike = "^1.1.2"
 scikit-learn = "^1.2.2"
@@ -51,6 +50,7 @@ httpx = "^0.24.1"
 pytest-asyncio = "^0.21.0"
 pytest-timeout = "^2.1.0"
 types-pyyaml = "^6.0.12.10"
+ruff = "^0.1.14"
 
 [tool.poetry.scripts]
 motion = "motion.cli:motioncli"

--- a/tests/test_expire_policies.py
+++ b/tests/test_expire_policies.py
@@ -1,9 +1,9 @@
 """
-This file tests the functionality to set expiration policies for update queues.
-We will test two expiration policies: NUM_NEW_UPDATES and SECONDS.
+This file tests the functionality to set discard policies for update queues.
+We will test two discard policies: NUM_NEW_UPDATES and SECONDS.
 We will test them in both sync and async functions.
 """
-from motion import Component, ExpirePolicy
+from motion import Component, DiscardPolicy
 import time
 import asyncio
 import pytest
@@ -16,7 +16,7 @@ def setup():
     return {"num_new_update_value": 0, "regular_value": 0, "seconds_value": 0}
 
 
-@C.update("sum", expire_after=10, expire_policy=ExpirePolicy.NUM_NEW_UPDATES)
+@C.update("sum", discard_after=10, discard_policy=DiscardPolicy.NUM_NEW_UPDATES)
 def update_sum_num_new(state, props):
     # Sleep for a bit so there's a real bottleneck in the update queue
     time.sleep(0.02)
@@ -28,13 +28,13 @@ def update_sum_default(state, props):
     return {"regular_value": state["regular_value"] + props["value"]}
 
 
-@C.update("sum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+@C.update("sum", discard_after=1, discard_policy=DiscardPolicy.SECONDS)
 def update_sum_seconds(state, props):
     time.sleep(0.05)
     return {"seconds_value": state["seconds_value"] + props["value"]}
 
 
-@C.update("asum", expire_after=10, expire_policy=ExpirePolicy.NUM_NEW_UPDATES)
+@C.update("asum", discard_after=10, discard_policy=DiscardPolicy.NUM_NEW_UPDATES)
 async def aupdate_sum_num_new(state, props):
     # Sleep for a bit so there's a real bottleneck in the update queue
     await asyncio.sleep(0.01)
@@ -46,7 +46,7 @@ async def aupdate_sum_default(state, props):
     return {"regular_value": state["regular_value"] + props["value"]}
 
 
-@C.update("asum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+@C.update("asum", discard_after=1, discard_policy=DiscardPolicy.SECONDS)
 async def aupdate_sum_seconds(state, props):
     await asyncio.sleep(0.05)
     return {"seconds_value": state["seconds_value"] + props["value"]}
@@ -66,11 +66,11 @@ def test_sync_num_new_updates():
     assert c.read_state("num_new_update_value") != 0
     assert c.read_state("seconds_value") != 0
 
-    # Assert that the num_new_update_value is not sum of 1..50 because there was the expiration policy
+    # Assert that the num_new_update_value is not sum of 1..50 because there was the discard policy
     assert c.read_state("num_new_update_value") != sum(range(50))
     assert c.read_state("seconds_value") != sum(range(50))
 
-    # Assert that regular_value is sum of 1..50 because there was no expiration policy
+    # Assert that regular_value is sum of 1..50 because there was no discard policy
     assert c.read_state("regular_value") == sum(range(50))
 
     c.shutdown()
@@ -94,11 +94,11 @@ async def test_async_num_new_updates():
     assert c.read_state("num_new_update_value") != 0
     assert c.read_state("seconds_value") != 0
 
-    # Assert that the num_new_update_value is not sum of 1..50 because there was the expiration policy
+    # Assert that the num_new_update_value is not sum of 1..50 because there was the discard policy
     assert c.read_state("num_new_update_value") != sum(range(50))
     assert c.read_state("seconds_value") != sum(range(50))
 
-    # Assert that regular_value is sum of 1..50 because there was no expiration policy
+    # Assert that regular_value is sum of 1..50 because there was no discard policy
     assert c.read_state("regular_value") == sum(range(50))
 
     c.shutdown()

--- a/tests/test_expire_policies.py
+++ b/tests/test_expire_policies.py
@@ -30,7 +30,7 @@ def update_sum_default(state, props):
 
 @C.update("sum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
 def update_sum_seconds(state, props):
-    time.sleep(0.02)
+    time.sleep(0.05)
     return {"seconds_value": state["seconds_value"] + props["value"]}
 
 
@@ -48,7 +48,7 @@ async def aupdate_sum_default(state, props):
 
 @C.update("asum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
 async def aupdate_sum_seconds(state, props):
-    await asyncio.sleep(0.02)
+    await asyncio.sleep(0.05)
     return {"seconds_value": state["seconds_value"] + props["value"]}
 
 

--- a/tests/test_expire_policies.py
+++ b/tests/test_expire_policies.py
@@ -19,7 +19,7 @@ def setup():
 @C.update("sum", expire_after=10, expire_policy=ExpirePolicy.NUM_NEW_UPDATES)
 def update_sum_num_new(state, props):
     # Sleep for a bit so there's a real bottleneck in the update queue
-    time.sleep(0.01)
+    time.sleep(0.02)
     return {"num_new_update_value": state["num_new_update_value"] + props["value"]}
 
 

--- a/tests/test_expire_policies.py
+++ b/tests/test_expire_policies.py
@@ -1,0 +1,104 @@
+"""
+This file tests the functionality to set expiration policies for update queues.
+We will test two expiration policies: NUM_NEW_UPDATES and SECONDS.
+We will test them in both sync and async functions.
+"""
+from motion import Component, ExpirePolicy
+import time
+import asyncio
+import pytest
+
+C = Component("C")
+
+
+@C.init_state
+def setup():
+    return {"num_new_update_value": 0, "regular_value": 0, "seconds_value": 0}
+
+
+@C.update("sum", expire_after=10, expire_policy=ExpirePolicy.NUM_NEW_UPDATES)
+def update_sum_num_new(state, props):
+    # Sleep for a bit so there's a real bottleneck in the update queue
+    time.sleep(0.01)
+    return {"num_new_update_value": state["num_new_update_value"] + props["value"]}
+
+
+@C.update("sum")
+def update_sum_default(state, props):
+    return {"regular_value": state["regular_value"] + props["value"]}
+
+
+@C.update("sum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+def update_sum_seconds(state, props):
+    time.sleep(0.02)
+    return {"seconds_value": state["seconds_value"] + props["value"]}
+
+
+@C.update("asum", expire_after=10, expire_policy=ExpirePolicy.NUM_NEW_UPDATES)
+async def aupdate_sum_num_new(state, props):
+    # Sleep for a bit so there's a real bottleneck in the update queue
+    await asyncio.sleep(0.01)
+    return {"num_new_update_value": state["num_new_update_value"] + props["value"]}
+
+
+@C.update("asum")
+async def aupdate_sum_default(state, props):
+    return {"regular_value": state["regular_value"] + props["value"]}
+
+
+@C.update("asum", expire_after=1, expire_policy=ExpirePolicy.SECONDS)
+async def aupdate_sum_seconds(state, props):
+    await asyncio.sleep(0.02)
+    return {"seconds_value": state["seconds_value"] + props["value"]}
+
+
+def test_sync_num_new_updates():
+    c = C()
+
+    for i in range(50):
+        c.run("sum", props={"value": i})
+
+    # Flush instance
+    c.flush_update("sum")
+
+    # Assert new state is different from old state
+    assert c.get_version() > 1
+    assert c.read_state("num_new_update_value") != 0
+    assert c.read_state("seconds_value") != 0
+
+    # Assert that the num_new_update_value is not sum of 1..50 because there was the expiration policy
+    assert c.read_state("num_new_update_value") != sum(range(50))
+    assert c.read_state("seconds_value") != sum(range(50))
+
+    # Assert that regular_value is sum of 1..50 because there was no expiration policy
+    assert c.read_state("regular_value") == sum(range(50))
+
+    c.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_async_num_new_updates():
+    c = C()
+
+    async_tasks = []
+    for i in range(50):
+        async_tasks.append(c.arun("asum", props={"value": i}))
+
+    await asyncio.gather(*async_tasks)
+
+    # Flush instance
+    c.flush_update("asum")
+
+    # Assert new state is different from old state
+    assert c.get_version() > 1
+    assert c.read_state("num_new_update_value") != 0
+    assert c.read_state("seconds_value") != 0
+
+    # Assert that the num_new_update_value is not sum of 1..50 because there was the expiration policy
+    assert c.read_state("num_new_update_value") != sum(range(50))
+    assert c.read_state("seconds_value") != sum(range(50))
+
+    # Assert that regular_value is sum of 1..50 because there was no expiration policy
+    assert c.read_state("regular_value") == sum(range(50))
+
+    c.shutdown()


### PR DESCRIPTION
Closes #293. This allows the user to define an `ExpirePolicy` for update ops that is either based on # seconds or # new updates. We also add documentation.